### PR TITLE
setup ocaml

### DIFF
--- a/.ocamlinit
+++ b/.ocamlinit
@@ -1,0 +1,5 @@
+#use "topfind";;
+#thread;;
+#camlp4o;;
+#require "core.top";;
+#require "core.syntax";;

--- a/.vimrc
+++ b/.vimrc
@@ -273,5 +273,22 @@ imap { {}<LEFT>
 imap [ []<LEFT>
 imap ( ()<LEFT>
 
+" merlin
+let g:opamshare = substitute(system('opam config var share'),'\n$','','''')
+execute 'set rtp+=' . g:opamshare . '/merlin/vim'
+
+" ocp-indent
+execute 'set rtp^=' . g:opamshare . '/ocp-indent/vim'
+function! s:ocaml_format()
+    let now_line = line('.')
+    exec ':%! ocp-indent'
+    exec ':' . now_line
+endfunction
+
+augroup ocaml_format
+    autocmd!
+    autocmd BufWrite,FileWritePre,FileAppendPre *.mli\= call s:ocaml_format()
+augroup END
+
 " filetypeの自動検出(最後の方に書いた方がいいらしい)
 filetype on

--- a/.vimrc
+++ b/.vimrc
@@ -290,5 +290,13 @@ augroup ocaml_format
     autocmd BufWrite,FileWritePre,FileAppendPre *.mli\= call s:ocaml_format()
 augroup END
 
+if executable('ocamllsp')
+  au User lsp_setup call lsp#register_server({
+        \ 'name': 'ocaml',
+        \ 'cmd': {server_info->['ocamllsp', '--fallback-read-dot-merlin']},
+        \ 'whitelist': ['ocaml'],
+        \ })
+endif
+
 " filetypeの自動検出(最後の方に書いた方がいいらしい)
 filetype on

--- a/.zshenv
+++ b/.zshenv
@@ -16,6 +16,7 @@ export AWS_DEFAULT_REGION='ap-northeast-1'
 export AWS_ASSUME_ROLE_TTL=12h
 export AWS_SESSION_TOKEN_TTL=12h
 export JAVA_HOME='/opt/homebrew/opt/openjdk@19/libexec/openjdk.jdk/Contents/Home'
+export OPAMROOT=$HOME/dotfiles/pkg/.opam
 
 # Language
 if [[ -z "$LANG" ]]; then

--- a/.zshrc
+++ b/.zshrc
@@ -65,4 +65,4 @@ if [ -e "$DOTFILES/pkg/.anyenv" ]; then
 fi
 
 # opam configuration
-[[ ! -r /Users/shun.tagami/.opam/opam-init/init.zsh ]] || source /Users/shun.tagami/.opam/opam-init/init.zsh  > /dev/null 2> /dev/null
+[[ ! -r $HOME/.opam/opam-init/init.zsh ]] || source $HOME/.opam/opam-init/init.zsh  > /dev/null 2>&1

--- a/.zshrc
+++ b/.zshrc
@@ -63,3 +63,6 @@ if [ -e "$DOTFILES/pkg/.anyenv" ]; then
     eval "$(anyenv init - zsh)"
   fi
 fi
+
+# opam configuration
+[[ ! -r /Users/shun.tagami/.opam/opam-init/init.zsh ]] || source /Users/shun.tagami/.opam/opam-init/init.zsh  > /dev/null 2> /dev/null

--- a/.zshrc
+++ b/.zshrc
@@ -65,4 +65,4 @@ if [ -e "$DOTFILES/pkg/.anyenv" ]; then
 fi
 
 # opam configuration
-[[ ! -r $HOME/.opam/opam-init/init.zsh ]] || source $HOME/.opam/opam-init/init.zsh  > /dev/null 2>&1
+[[ ! -r $DOTFILES/pkg/.opam/opam-init/init.zsh ]] || source $DOTFILES/pkg/.opam/opam-init/init.zsh  > /dev/null 2>&1

--- a/misc/Brewfile
+++ b/misc/Brewfile
@@ -94,6 +94,7 @@ brew "mysql@5.7", restart_service: true, link: true
 brew "node"
 brew "newman"
 brew "nghttp2"
+brew "opam"
 brew "openjdk@11"
 brew "openjdk@17"
 brew "openssl@3", link: true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,6 +24,7 @@ ln -sf ~/dotfiles/.gitignore_global ~/.gitignore_global
 ln -sf ~/dotfiles/.golangci.yml ~/.golangci.yml
 ln -sf ~/dotfiles/.my.cnf ~/.my.cnf
 ln -sf ~/dotfiles/.npmrc ~/.npmrc
+ln -sf ~/dotfiles/.ocamlinit ~/.ocamlinit
 ln -sf ~/dotfiles/.vimrc ~/.vimrc
 ln -sf ~/dotfiles/.zpreztorc ~/.zpreztorc
 ln -sf ~/dotfiles/.zshenv ~/.zshenv

--- a/vscode/extensions
+++ b/vscode/extensions
@@ -43,6 +43,7 @@ mubaidr.vuejs-extension-pack
 naco-siren.gradle-language
 naoray.laravel-goto-components
 nmrmsys.vscode-sql-formatter-mod
+ocamllabs.ocaml-platform
 oderwat.indent-rainbow
 onecentlin.laravel-blade
 onecentlin.laravel-extension-pack

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -135,6 +135,9 @@
   "java.jdt.ls.java.home": "/opt/homebrew/opt/openjdk@19/libexec/openjdk.jdk/Contents/Home",
   "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml",
   "java.format.settings.profile": "GoogleStyle",
+  "ocaml.server.extraEnv": {
+    "OCAMLLSP_SEMANTIC_HIGHLIGHTING": "full"
+  },
   "explorer.autoReveal": false,
   "launch": {
     "version": "0.2.0",

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -138,6 +138,7 @@
   "ocaml.server.extraEnv": {
     "OCAMLLSP_SEMANTIC_HIGHLIGHTING": "full"
   },
+  "ocaml.server.args": ["--fallback-read-dot-merlin"],
   "explorer.autoReveal": false,
   "launch": {
     "version": "0.2.0",


### PR DESCRIPTION
## what
- brew install opam
- opam init

## memo
```
❯ ocaml
        OCaml version 4.12.0

# "あ" ;;
- : string = "あ"
#
```

```
❯ utop
──────────────────────────────────────────┬──────────────────────────────────────────────────────────────┬───────────────────────────────────────────
                                          │ Welcome to utop version 2.11.0 (using OCaml version 4.12.0)! │
                                          └──────────────────────────────────────────────────────────────┘
Findlib has been successfully loaded. Additional directives:
  #require "package";;      to load a package
  #list;;                   to list the available packages
  #camlp4o;;                to load camlp4 (standard syntax)
  #camlp4r;;                to load camlp4 (revised syntax)
  #predicates "p,q,...";;   to set these predicates
  Topfind.reset();;         to force that packages will be reloaded
  #thread;;                 to enable threads

No such package: camlp4
No such package: core.syntax

Type #utop_help for help about using utop.
```

sample .merlin for https://github.com/johnwhitington/cpdf-source, but working only in VSCode.

```
S .
B _build
FLG -unsafe-string
PKG camlpdf
```
<img width="650" alt="image" src="https://user-images.githubusercontent.com/69618840/223723770-5413e377-9e55-4835-8edb-8fd06559e845.png">

<img width="932" alt="image" src="https://user-images.githubusercontent.com/69618840/223723616-aac88071-99dc-427f-b016-d7223088fc66.png">
