### PR TITLE
fix/macos/dock

### DIFF
--- a/scripts/macos.sh
+++ b/scripts/macos.sh
@@ -288,8 +288,8 @@ defaults write com.apple.finder FXInfoPanesExpanded -dict \
 # Enable highlight hover effect for the grid view of a stack (Dock)
 defaults write com.apple.dock mouse-over-hilite-stack -bool true
 
-# Set the icon size of Dock items to 36 pixels
-defaults write com.apple.dock tilesize -int 36
+# Set the icon size of Dock items to 24 pixels
+defaults write com.apple.dock "tilesize" -int "24"
 
 # Change minimize/maximize window effect
 defaults write com.apple.dock mineffect -string "scale"

--- a/scripts/macos.sh
+++ b/scripts/macos.sh
@@ -344,6 +344,9 @@ defaults write com.apple.dock showhidden -bool true
 # Don’t show recent applications in Dock
 defaults write com.apple.dock show-recents -bool false
 
+# Put the Dock on the left of the screen
+defaults write com.apple.dock "orientation" -string "left"
+
 # Disable the Launchpad gesture (pinch with thumb and three fingers)
 #defaults write com.apple.dock showLaunchpadGestureEnabled -int 0
 

--- a/scripts/macos.sh
+++ b/scripts/macos.sh
@@ -353,9 +353,6 @@ defaults write com.apple.dock "orientation" -string "left"
 # Reset Launchpad, but keep the desktop wallpaper intact
 find "${HOME}/Library/Application Support/Dock" -name "*-*.db" -maxdepth 1 -delete
 
-# Add iOS & Watch Simulator to Launchpad
-sudo ln -sf "/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app" "/Applications/Simulator.app"
-sudo ln -sf "/Applications/Xcode.app/Contents/Developer/Applications/Simulator (Watch).app" "/Applications/Simulator (Watch).app"
 
 # Hot corners
 # Possible values:

--- a/scripts/macos.sh
+++ b/scripts/macos.sh
@@ -306,10 +306,10 @@ defaults write com.apple.dock show-process-indicators -bool true
 # Wipe all (default) app icons from the Dock
 # This is only really useful when setting up a new Mac, or if you don’t use
 # the Dock to launch apps.
-#defaults write com.apple.dock persistent-apps -array
+defaults write com.apple.dock persistent-apps -array
 
 # Show only open applications in the Dock
-#defaults write com.apple.dock static-only -bool true
+defaults write com.apple.dock static-only -bool true
 
 # Don’t animate opening applications from the Dock
 defaults write com.apple.dock launchanim -bool false


### PR DESCRIPTION
close https://github.com/shuntagami/dotfiles/issues/31
- Show only open applications in the Dock
- Put the Dock on the left of the screen
- fix icon size
- tweak
