### PR TITLE
use left alt as command key

### DIFF
--- a/win/autohotkey/macKeyboard.ahk
+++ b/win/autohotkey/macKeyboard.ahk
@@ -17,10 +17,10 @@
 ; --------------------------------------------------------------
 
 ; Capture entire screen with CMD/WIN + SHIFT + 3
-#+3::Send("#{PrintScreen}")
+$!+3::Send("#{PrintScreen}")
 
 ; Capture portion of the screen with CMD/WIN + SHIFT + 4
-#+4::Send("+#s")
+$!+4::Send("+#s")
 
 ; --------------------------------------------------------------
 ; media/function keys all mapped to the right option key
@@ -61,52 +61,50 @@
 ; --------------------------------------------------------------
 
 ; Make Ctrl + S work with cmd (windows) key
-#s::Send("^s")
+$!s::Send("^s")
 
 ; Selecting
-#a::Send("^a")
+$!a::Send("^a")
 
 ; Copying
-#c::Send("^c")
+$!c::Send("^c")
 
 ; Pasting
-#v::Send("^v")
+$!v::Send("^v")
 
 ; Cutting
-#x::Send("^x")
+$!x::Send("^x")
 
 ; Opening
-#o::Send("^o")
+$!o::Send("^o")
 
 ; Finding
-#f::Send("^f")
+$!f::Send("^f")
 
 ; Undo
-#z::Send("^z")
+$!z::Send("^z")
 
 ; Redo
-#y::Send("^y")
+$!y::Send("^y")
 
 ; New tab
-#t::Send("^t")
+$!t::Send("^t")
 
 ; close tab
-#w::Send("^w")
+$!w::Send("^w")
 
 ; Reload
-#r::Send("^r")
+$!r::Send("^r")
+$!+r::Send("^+r")
 
 ; Close windows (cmd + q to Alt + F4)
-#q::Send("!{F4}")
+$!q::Send("!{F4}")
 
-#Enter::Send("^{Enter}")
-#+Enter::Send("^+{Enter}")
-
-; Remap Windows + Tab to Alt + Tab.
-Lwin & Tab::AltTab
+$!Enter::Send("^{Enter}")
+$!+Enter::Send("^+{Enter}")
 
 ; minimize windows
-#m::WinMinimize("A")
+$!m::WinMinimize("A")
 
 ; --------------------------------------------------------------
 ; OS X keyboard mappings for special chars

--- a/win/autohotkey/macKeyboard.ahk
+++ b/win/autohotkey/macKeyboard.ahk
@@ -106,6 +106,12 @@ $!+Enter::Send("^+{Enter}")
 ; minimize windows
 $!m::WinMinimize("A")
 
+; bind the arrow keys to alt+hjkl
+$!h::Send("{left}")
+$!j::Send("{down}")
+$!k::Send("{up}")
+$!l::Send("{right}")
+
 ; --------------------------------------------------------------
 ; OS X keyboard mappings for special chars
 ; --------------------------------------------------------------


### PR DESCRIPTION
# memo

![image](https://github.com/user-attachments/assets/135c5d9b-b4f4-4dcd-80da-fc6f3849680f)


![image](https://github.com/user-attachments/assets/d968ceee-60a1-4afb-8fcf-09025068fca6)

Left Alt + Shift が Switch Input Language に割り当てられていてるのでunassignedにする必要がある。これにより[なぜかLeft Alt + Shift + 3 or 4 でOffice 365が起動する](https://answers.microsoft.com/en-us/msoffice/forum/all/microsoft-office-start-whenever-i-press-ctrl-or/ae969009-c128-430f-a845-f756875a17c7)のも直った https://www.autohotkey.com/boards/viewtopic.php?t=115117

https://superuser.com/questions/698037/can-i-disable-the-altshift-shortcut-to-change-language-in-windows-8-1-or-win