### PR TITLE
Unify setup into a single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MacOS / Ubuntu dotfiles.
 
 With this dotfiles, it
 
-- allows you to setup dev environment in **just 3 commands** 🚀.
+- allows you to setup dev environment in **just 1 command** 🚀.
 - would work **both on MacOS and Ubuntu**✨.
 
 ## Requirement
@@ -18,35 +18,30 @@ $ xcode-select --install
 
 ## How to use
 
-Run the following commnad.
-
 ```bash
+# 1. Download dotfiles
 $ bash -c "$(curl -fsSL raw.githubusercontent.com/shuntagami/dotfiles/main/scripts/install-dotfiles.sh)"
-$ ~/dotfiles/scripts/install-packages.sh
-$ ~/dotfiles/scripts/deploy.sh
+
+# 2. Run setup (packages, symlinks, macOS settings, VSCode — all in one)
+$ ~/dotfiles/scripts/setup.sh
 ```
 
-### For Mac user
+### Run individual steps manually
 
-- Setup macOS.
+You can also run each step separately if needed.
 
 ```bash
-$ ~/dotfiles/scripts/macos.sh
+$ ~/dotfiles/scripts/install-packages.sh  # Install Homebrew, anyenv, etc.
+$ ~/dotfiles/scripts/deploy.sh            # Symlink dotfiles
+$ ~/dotfiles/scripts/macos.sh             # Configure macOS defaults
+$ ~/dotfiles/vscode/setup.sh              # Set up VSCode/Cursor
 ```
 
-- Setup Iterm.
+### iTerm2
 
 _(Preferences(⌘,)_ → _Preferences_ → check <b>Load preferences from a custom folder or URL</b>, change it to <b>/Users/Username/dotfiles/misc</b>)
 
 ![sample](https://user-images.githubusercontent.com/69618840/153607360-dc173d13-c551-4f2c-9ce5-02cbfeb0a120.png)
-
-### For Visual Studio Code user
-
-- Setup Visual Studio Code
-
-```bash
-$ ~/dotfiles/vscode/setup.sh
-```
 
 ## Keywords
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ $ ~/dotfiles/scripts/macos.sh             # Configure macOS defaults
 $ ~/dotfiles/vscode/setup.sh              # Set up VSCode/Cursor
 ```
 
-### iTerm2
-
-_(Preferences(⌘,)_ → _Preferences_ → check <b>Load preferences from a custom folder or URL</b>, change it to <b>/Users/Username/dotfiles/misc</b>)
-
-![sample](https://user-images.githubusercontent.com/69618840/153607360-dc173d13-c551-4f2c-9ce5-02cbfeb0a120.png)
-
 ## Keywords
 
 - [Zsh](https://www.zsh.org/)([sorin-ionescu/prezto](https://github.com/sorin-ionescu/prezto))

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ With this dotfiles, it
 - XCode Command Line Tools(for Mac user. if you don't have, get by runnning following command.)
 
 ```bash
-$ xcode-select --install
+xcode-select --install
 ```
 
 ## How to use
 
 ```bash
 # 1. Download dotfiles
-$ bash -c "$(curl -fsSL raw.githubusercontent.com/shuntagami/dotfiles/main/scripts/install-dotfiles.sh)"
+bash -c "$(curl -fsSL raw.githubusercontent.com/shuntagami/dotfiles/main/scripts/install-dotfiles.sh)"
 
 # 2. Run setup (packages, symlinks, macOS settings, VSCode — all in one)
-$ ~/dotfiles/scripts/setup.sh
+~/dotfiles/scripts/setup.sh
 ```
 
 ### Run individual steps manually
@@ -31,10 +31,10 @@ $ ~/dotfiles/scripts/setup.sh
 You can also run each step separately if needed.
 
 ```bash
-$ ~/dotfiles/scripts/install-packages.sh  # Install Homebrew, anyenv, etc.
-$ ~/dotfiles/scripts/deploy.sh            # Symlink dotfiles
-$ ~/dotfiles/scripts/macos.sh             # Configure macOS defaults
-$ ~/dotfiles/vscode/setup.sh              # Set up VSCode/Cursor
+~/dotfiles/scripts/install-packages.sh  # Install Homebrew, anyenv, etc.
+~/dotfiles/scripts/deploy.sh            # Symlink dotfiles
+~/dotfiles/scripts/macos.sh             # Configure macOS defaults
+~/dotfiles/vscode/setup.sh              # Set up VSCode/Cursor
 ```
 
 ## Keywords

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -45,6 +45,6 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 # change shell
-sudo chsh -s $(which zsh) $USER
+sudo chsh -s $(which zsh) $(id -un)
 
 echo "Deploy complete! Run 'exec \$SHELL -l' to reload your shell."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -45,6 +45,6 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 # change shell
-chsh -s $(which zsh)
+sudo chsh -s $(which zsh) $USER
 
 echo "Deploy complete! Run 'exec \$SHELL -l' to reload your shell."

--- a/scripts/macos.sh
+++ b/scripts/macos.sh
@@ -498,6 +498,14 @@ sudo scutil --set ComputerName "Shun-Tagami-MacBook"
 sudo scutil --set LocalHostName "Shun-Tagami-MacBook"
 
 ###############################################################################
+# iTerm2                                                                      #
+###############################################################################
+
+# Load preferences from custom folder
+defaults write com.googlecode.iterm2 PrefsCustomFolder -string "~/dotfiles/misc"
+defaults write com.googlecode.iterm2 LoadPrefsFromCustomFolder -bool true
+
+###############################################################################
 # Kill affected applications                                                  #
 ###############################################################################
 

--- a/scripts/macos.sh
+++ b/scripts/macos.sh
@@ -502,7 +502,7 @@ sudo scutil --set LocalHostName "Shun-Tagami-MacBook"
 ###############################################################################
 
 # Load preferences from custom folder
-defaults write com.googlecode.iterm2 PrefsCustomFolder -string "~/dotfiles/misc"
+defaults write com.googlecode.iterm2 PrefsCustomFolder -string "$HOME/dotfiles/misc"
 defaults write com.googlecode.iterm2 LoadPrefsFromCustomFolder -bool true
 
 ###############################################################################

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -eu
+
+DOTFILES="${HOME}/dotfiles"
+
+echo "Starting dotfiles setup..."
+
+# Ask for the administrator password upfront (once)
+sudo -v
+# Keep-alive: update existing sudo time stamp until setup has finished
+while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
+
+# Phase 1: Install packages
+echo "==> Installing packages..."
+bash "${DOTFILES}/scripts/install-packages.sh"
+
+# Phase 2: Deploy dotfiles (symlinks)
+echo "==> Deploying dotfiles..."
+zsh "${DOTFILES}/scripts/deploy.sh"
+
+# Phase 3: macOS / editor settings (macOS only)
+if [[ "$(uname)" == "Darwin" ]]; then
+  echo "==> Configuring macOS defaults..."
+  bash "${DOTFILES}/scripts/macos.sh"
+
+  echo "==> Setting up VSCode/Cursor..."
+  DOTFILES_AUTO=1 bash "${DOTFILES}/vscode/setup.sh"
+fi
+
+echo "Setup complete! Run 'exec \$SHELL -l' to reload your shell."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -euo pipefail
 
 DOTFILES="${HOME}/dotfiles"
 

--- a/vscode/setup.sh
+++ b/vscode/setup.sh
@@ -34,6 +34,10 @@ get_setting_dirs() {
 # 確認プロンプト関数
 confirm_replace() {
   local file_path=$1
+  # Auto-approve when called from setup.sh
+  if [[ "${DOTFILES_AUTO:-}" == "1" ]]; then
+    return 0
+  fi
   echo "Warning: ${file_path} already exists and is not a symlink."
   read -p "Do you want to replace it with a symlink? (y/N): " -n 1 -r
   echo


### PR DESCRIPTION
## Summary
- 3コマンド+αだったセットアップを `setup.sh` 1コマンドに統合
- sudo keep-alive により**パスワード入力を1回だけ**に削減
- `chsh` を `sudo chsh` に変更して keep-alive の恩恵を受けるように
- `vscode/setup.sh` の対話プロンプトを `DOTFILES_AUTO=1` でスキップ可能に

## セットアップ手順 (変更後)
```bash
# 1. Download
bash -c "$(curl -fsSL raw.githubusercontent.com/shuntagami/dotfiles/main/scripts/install-dotfiles.sh)"

# 2. Setup (packages, symlinks, macOS defaults, VSCode — all in one)
~/dotfiles/scripts/setup.sh
```

## Test plan
- [ ] 新規Macで `setup.sh` を実行してパスワードが1回だけ求められることを確認
- [ ] 各スクリプトの単体実行が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * セットアップ手順をさらに簡素化し、1つのコマンドでの実行を前面に表示。

* **新機能**
  * 自動セットアップスクリプトを追加し、パッケージ導入・ドットファイル展開・システム設定を一括実行可能に。

* **チューニング**
  * シェルのデフォルト変更で管理者権限を明示的に使用するよう変更。
  * エディタ設定の置換確認を環境変数で自動承認できるように実装。
  * iTerm2のカスタム設定フォルダを読み込む設定を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->