### PR TITLE
Track Crossnote config in dotfiles

### DIFF
--- a/misc/README.md
+++ b/misc/README.md
@@ -2,6 +2,14 @@
 
 各種アプリケーションの設定ファイル。
 
+## crossnote/
+
+Crossnote のカスタム parser / style 設定。
+
+- `parser.js`: `:::memo` などの callout 記法を HTML に変換する
+- `style.less`: preview / PDF 向けの見た目を整える
+- `scripts/deploy.sh` から `~/.local/state/crossnote/` にシンボリックリンクされる
+
 ## gcp-oauth.keys.json
 
 Google Calendar MCP サーバー用の OAuth 認証情報。

--- a/misc/crossnote/parser.js
+++ b/misc/crossnote/parser.js
@@ -1,0 +1,78 @@
+({
+  onWillParseMarkdown: async function (markdown) {
+    // ========================
+    // SVG ICON DEFINITIONS
+    // ========================
+    const SVG_ICONS = {
+      memo: `
+    <svg width="20" height="20" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+      <path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z"/>
+    </svg>
+  `,
+      info: `
+    <svg width="20" height="20" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+      <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/>
+    </svg>
+  `,
+      checkBox: `
+    <svg width="20" height="20" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+      <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"/>
+    </svg>
+  `,
+      exclamation: `
+    <svg width="20" height="20" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+      <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/>
+    </svg>
+  `,
+      xmark: `
+    <svg width="20" height="20" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+      <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c9.4-9.4 24.6-9.4 33.9 0l47 47 47-47c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-47 47 47 47c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-47-47-47 47c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l47-47-47-47c-9.4-9.4-9.4-24.6 0-33.9z"/>
+    </svg>
+  `,
+    };
+
+    // ========================
+    // CALLOUT TYPE DEFINITIONS
+    // ========================
+    const CALLOUT_TYPES = [
+      { type: 'memo', icon: SVG_ICONS.memo },
+      { type: 'alert', icon: SVG_ICONS.xmark },
+      { type: 'info', icon: SVG_ICONS.info },
+      { type: 'warn', icon: SVG_ICONS.exclamation },
+      // { type: "success", icon: SVG_ICONS.checkBox }, // 追加したければ有効化
+    ];
+
+    // ========================
+    // REPLACE :::type ... ::: WITH HTML
+    // ========================
+    function replaceCallout(markdown, type, icon) {
+      const regex = new RegExp(`:::${type}[\\s\\S]*?:::`, 'gm');
+
+      markdown = markdown.replace(regex, (match) => {
+        // 先頭の ":::type" と末尾の ":::"
+        const rawContent = match.slice(type.length + 3, -3).trimStart();
+        const content = '\n' + rawContent;
+
+        return `
+<div class="InlineCalloutElement callout-${type}">
+  <div class="IconContainer">${icon}</div>
+  <div class="ContentContainer">${content}</div>
+</div>
+`;
+      });
+
+      return markdown;
+    }
+
+    for (const { type, icon } of CALLOUT_TYPES) {
+      markdown = replaceCallout(markdown, type, icon);
+    }
+
+    return markdown;
+  },
+
+  onDidParseMarkdown: async function (html) {
+    // ここで後処理をしたい場合は追記する
+    return html;
+  },
+});

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -14,7 +14,7 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    background-color: #f5f5f7; // 落ち着いた薄グレー
+    background-color: #ffffff; // Cursor Quiet Light の背景に合わせる
     color: #222222;
     font-family:
       -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI',

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -1,0 +1,267 @@
+.main() {
+  /* =========================
+   *  全体レイアウト・背景
+   * ========================= */
+
+  body,
+  .markdown-preview.markdown-preview {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    background-color: #f5f5f7; // 落ち着いた薄グレー
+    color: #222222;
+    font-family:
+      -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI',
+      'YuGothic', 'Yu Gothic Medium', 'Yu Gothic', sans-serif;
+    text-size-adjust: 100%;
+  }
+
+  .markdown-preview.markdown-preview {
+    max-width: 900px;
+    margin: 24px auto 48px;
+    padding: 32px 28px 40px;
+    box-sizing: border-box;
+    background-color: #ffffff; // 本文エリアは白い紙
+    border-radius: 12px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.06);
+  }
+
+  /* =========================
+   *  ベースタイポグラフィ
+   * ========================= */
+
+  p {
+    font-size: 15px;
+    line-height: 1.7;
+    margin: 0 0 12px;
+  }
+
+  strong {
+    font-weight: 600;
+  }
+
+  em {
+    font-style: normal;
+    font-weight: 500;
+  }
+
+  a {
+    color: #2563eb;
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+
+  /* =========================
+   *  見出し
+   * ========================= */
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-weight: 700;
+    line-height: 1.4;
+    color: #111827;
+  }
+
+  h1 {
+    font-size: 24px; // デカすぎないよう抑える
+    margin: 0 0 16px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  h2 {
+    font-size: 20px;
+    margin: 32px 0 12px;
+    border-left: 3px solid #4b5563;
+    padding-left: 8px;
+  }
+
+  h3 {
+    font-size: 17px;
+    margin: 24px 0 8px;
+    color: #374151;
+  }
+
+  h4 {
+    font-size: 15px;
+    margin: 20px 0 8px;
+    color: #4b5563;
+  }
+
+  /* =========================
+   *  段落・リスト・引用
+   * ========================= */
+
+  ul,
+  ol {
+    margin: 0 0 12px 22px;
+    padding: 0;
+  }
+
+  li {
+    margin: 2px 0;
+    line-height: 1.6;
+  }
+
+  blockquote {
+    margin: 12px 0;
+    padding: 8px 12px;
+    border-left: 3px solid #d1d5db;
+    background-color: #f9fafb;
+    color: #4b5563;
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid #e5e7eb;
+    margin: 24px 0;
+  }
+
+  /* =========================
+   *  コード・テーブル
+   * ========================= */
+
+  code {
+    font-family:
+      SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+      monospace;
+    font-size: 13px;
+    background-color: #f3f4f6;
+    padding: 1px 4px;
+    border-radius: 4px;
+  }
+
+  pre {
+    margin: 16px 0;
+    padding: 12px 14px;
+    background-color: #0f172a;
+    color: #e5e7eb;
+    border-radius: 8px;
+    overflow: auto;
+    font-size: 13px;
+    line-height: 1.6;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+  }
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 16px 0;
+    font-size: 14px;
+  }
+
+  th,
+  td {
+    border: 1px solid #e5e7eb;
+    padding: 8px 10px;
+    text-align: left;
+  }
+
+  th {
+    background-color: #f9fafb;
+    font-weight: 600;
+  }
+
+  /* =========================
+   *  コールアウト共通
+   * ========================= */
+
+  .InlineCalloutElement {
+    padding: 14px 16px;
+    margin: 0 0 18px;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: flex-start;
+  }
+
+  .IconContainer {
+    display: block;
+    line-height: 0;
+    box-sizing: border-box;
+    text-align: start;
+  }
+
+  .IconContainer svg {
+    display: block;
+  }
+
+  .ContentContainer {
+    display: block;
+    box-sizing: border-box;
+    font-size: 14px;
+    line-height: 1.7;
+    margin-inline-start: 10px;
+    text-align: start;
+    text-size-adjust: 100%;
+  }
+
+  .ContentContainer > p {
+    margin-bottom: 0;
+  }
+
+  /* =========================
+   *  コールアウト個別
+   * ========================= */
+
+  /* メモ用（ライトグレー） */
+  .callout-memo {
+    background-color: #f8fafc;
+    border-color: #e5e7eb;
+    color: #111827;
+    fill: #6b7280;
+  }
+
+  /* 重要警告（赤系） */
+  .callout-alert {
+    color: #991b1b;
+    fill: #dc2626;
+    background-color: #fef2f2;
+    border-color: #fecaca;
+  }
+
+  /* ポジティブ／成功（緑系） */
+  .callout-info {
+    color: #166534;
+    fill: #16a34a;
+    background-color: #ecfdf3;
+    border-color: #bbf7d0;
+  }
+
+  /* 注意喚起（黄系） */
+  .callout-warn {
+    color: #854d0e;
+    fill: #f59e0b;
+    background-color: #fffbeb;
+    border-color: #fef3c7;
+  }
+
+  /* =========================
+   *  画像・その他
+   * ========================= */
+
+  img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 4px;
+  }
+}
+
+/* bodyとmarkdown-preview.markdown-previewに適用して、previewとpdfのCSSを共通にする */
+.main;
+
+.markdown-preview.markdown-preview {
+  .main;
+}

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -39,7 +39,7 @@
   p {
     font-size: 15px;
     line-height: 1.66;
-    margin: 0 0 12px;
+    margin: 0 0 10px;
   }
 
   strong {

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -85,8 +85,6 @@
   h2 {
     font-size: 20px;
     margin: 32px 0 12px;
-    border-left: 3px solid #4b5563;
-    padding-left: 8px;
   }
 
   h3 {

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -38,7 +38,7 @@
 
   p {
     font-size: 15px;
-    line-height: 1.66;
+    line-height: 1.6;
     margin: 0 0 10px;
   }
 

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -79,12 +79,12 @@
     font-size: 24px; // デカすぎないよう抑える
     margin: 0 0 16px;
     padding-bottom: 8px;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid #eef2f7;
   }
 
   h2 {
     font-size: 20px;
-    margin: 32px 0 12px;
+    margin: 28px 0 10px;
   }
 
   h3 {

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -38,8 +38,8 @@
 
   p {
     font-size: 15px;
-    line-height: 1.6;
-    margin: 0 0 10px;
+    line-height: 1.52;
+    margin: 0 0 8px;
   }
 
   strong {
@@ -111,7 +111,7 @@
 
   li {
     margin: 2px 0;
-    line-height: 1.6;
+    line-height: 1.52;
   }
 
   blockquote {

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -1,4 +1,8 @@
 @sidebar-toc-width: 268px;
+@toc-link-color: #4b5563;
+@toc-link-hover-color: #1f2937;
+@toc-link-hover-bg: #f3f4f6;
+@toc-link-active-bg: #e5e7eb;
 
 .main() {
   /* =========================
@@ -268,6 +272,38 @@
  * ========================= */
 
 .preview-container.show-sidebar-toc {
+  .md-sidebar-toc {
+    a {
+      color: @toc-link-color;
+    }
+
+    .md-toc-link {
+      display: block;
+      padding: 4px 8px;
+      border-radius: 6px;
+      cursor: pointer;
+      transition:
+        background-color 120ms ease,
+        color 120ms ease;
+    }
+
+    .md-toc-link:hover {
+      color: @toc-link-hover-color;
+      background-color: @toc-link-hover-bg;
+      text-decoration: none;
+    }
+
+    .md-toc-link:active {
+      background-color: @toc-link-active-bg;
+    }
+
+    .md-toc-link-wrapper.highlighted .md-toc-link {
+      color: @toc-link-hover-color;
+      font-weight: 600;
+      background-color: @toc-link-hover-bg;
+    }
+  }
+
   .crossnote {
     width: calc(~'100% - ' @sidebar-toc-width);
   }

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -1,3 +1,13 @@
+@sidebar-toc-width: 232px;
+@preview-gap-x: 10px;
+@preview-gap-y: 14px;
+@surface-border: #e5e7eb;
+@sidebar-bg: #f8fafc;
+@sidebar-link-color: #475569;
+@sidebar-link-hover-bg: #eef2ff;
+@sidebar-link-active-bg: #dbeafe;
+@sidebar-link-active-color: #1d4ed8;
+
 .main() {
   /* =========================
    *  全体レイアウト・背景
@@ -256,6 +266,85 @@
     max-width: 100%;
     height: auto;
     border-radius: 4px;
+  }
+}
+
+/* =========================
+ *  Preview shell overrides
+ *  TOC表示時は本文を中央寄せカードにせず、
+ *  右側の目次との間隔を詰める
+ * ========================= */
+
+.preview-container.show-sidebar-toc {
+  .md-sidebar-toc {
+    width: @sidebar-toc-width;
+    padding: 20px 0 28px;
+    background-color: @sidebar-bg;
+    border-left: 1px solid @surface-border;
+    box-shadow: none;
+  }
+
+  .md-sidebar-toc .md-toc {
+    padding: 0 12px;
+  }
+
+  .md-sidebar-toc .md-toc-link-wrapper {
+    margin-bottom: 2px;
+  }
+
+  .md-sidebar-toc .md-toc-link {
+    display: block;
+    padding: 6px 10px;
+    border-radius: 8px;
+    color: @sidebar-link-color;
+    line-height: 1.45;
+    transition:
+      background-color 120ms ease,
+      color 120ms ease;
+  }
+
+  .md-sidebar-toc .md-toc-link:hover {
+    background-color: @sidebar-link-hover-bg;
+    color: @sidebar-link-active-color;
+    text-decoration: none;
+  }
+
+  .md-sidebar-toc .md-toc-link-wrapper.highlighted .md-toc-link {
+    font-weight: 700;
+    color: @sidebar-link-active-color;
+    background-color: @sidebar-link-active-bg;
+  }
+
+  .crossnote {
+    width: calc(~'100% - ' @sidebar-toc-width);
+    background-color: transparent;
+  }
+
+  .crossnote.markdown-preview[data-for='preview'] {
+    max-width: none;
+    margin: @preview-gap-y @preview-gap-x 32px @preview-gap-x;
+    padding: 30px 32px 40px;
+    border: 1px solid @surface-border;
+    border-radius: 14px;
+    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
+  }
+}
+
+@media screen and (max-width: 1200px) {
+  .preview-container.show-sidebar-toc {
+    .md-sidebar-toc {
+      width: 220px;
+    }
+
+    .crossnote {
+      width: calc(~'100% - 220px');
+    }
+
+    .crossnote.markdown-preview[data-for='preview'] {
+      margin: 10px 8px 24px 8px;
+      padding: 26px 26px 34px;
+      border-radius: 12px;
+    }
   }
 }
 

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -273,6 +273,8 @@
 
 .preview-container.show-sidebar-toc {
   .md-sidebar-toc {
+    box-shadow: none;
+
     a {
       color: @toc-link-color;
     }

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -1,12 +1,4 @@
-@sidebar-toc-width: 232px;
-@preview-gap-x: 10px;
-@preview-gap-y: 14px;
-@surface-border: #e5e7eb;
-@sidebar-bg: #f8fafc;
-@sidebar-link-color: #475569;
-@sidebar-link-hover-bg: #eef2ff;
-@sidebar-link-active-bg: #dbeafe;
-@sidebar-link-active-color: #1d4ed8;
+@sidebar-toc-width: 268px;
 
 .main() {
   /* =========================
@@ -271,80 +263,20 @@
 
 /* =========================
  *  Preview shell overrides
- *  TOC表示時は本文を中央寄せカードにせず、
- *  右側の目次との間隔を詰める
+ *  TOC表示時だけ、本文パネルの右端を
+ *  目次にフラットにつなげる
  * ========================= */
 
 .preview-container.show-sidebar-toc {
-  .md-sidebar-toc {
-    width: @sidebar-toc-width;
-    padding: 20px 0 28px;
-    background-color: @sidebar-bg;
-    border-left: 1px solid @surface-border;
-    box-shadow: none;
-  }
-
-  .md-sidebar-toc .md-toc {
-    padding: 0 12px;
-  }
-
-  .md-sidebar-toc .md-toc-link-wrapper {
-    margin-bottom: 2px;
-  }
-
-  .md-sidebar-toc .md-toc-link {
-    display: block;
-    padding: 6px 10px;
-    border-radius: 8px;
-    color: @sidebar-link-color;
-    line-height: 1.45;
-    transition:
-      background-color 120ms ease,
-      color 120ms ease;
-  }
-
-  .md-sidebar-toc .md-toc-link:hover {
-    background-color: @sidebar-link-hover-bg;
-    color: @sidebar-link-active-color;
-    text-decoration: none;
-  }
-
-  .md-sidebar-toc .md-toc-link-wrapper.highlighted .md-toc-link {
-    font-weight: 700;
-    color: @sidebar-link-active-color;
-    background-color: @sidebar-link-active-bg;
-  }
-
   .crossnote {
     width: calc(~'100% - ' @sidebar-toc-width);
-    background-color: transparent;
   }
 
   .crossnote.markdown-preview[data-for='preview'] {
     max-width: none;
-    margin: @preview-gap-y @preview-gap-x 32px @preview-gap-x;
-    padding: 30px 32px 40px;
-    border: 1px solid @surface-border;
-    border-radius: 14px;
-    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
-  }
-}
-
-@media screen and (max-width: 1200px) {
-  .preview-container.show-sidebar-toc {
-    .md-sidebar-toc {
-      width: 220px;
-    }
-
-    .crossnote {
-      width: calc(~'100% - 220px');
-    }
-
-    .crossnote.markdown-preview[data-for='preview'] {
-      margin: 10px 8px 24px 8px;
-      padding: 26px 26px 34px;
-      border-radius: 12px;
-    }
+    margin: 0 0 48px;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
   }
 }
 

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -14,7 +14,7 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    background-color: #ffffff; // Cursor Quiet Light の背景に合わせる
+    background-color: var(--vscode-editor-background, #f5f5f5);
     color: #222222;
     font-family:
       -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI',

--- a/misc/crossnote/style.less
+++ b/misc/crossnote/style.less
@@ -38,7 +38,7 @@
 
   p {
     font-size: 15px;
-    line-height: 1.7;
+    line-height: 1.66;
     margin: 0 0 12px;
   }
 
@@ -90,7 +90,7 @@
   h3 {
     font-size: 17px;
     margin: 24px 0 8px;
-    color: #374151;
+    color: #334155;
   }
 
   h4 {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -45,6 +45,9 @@ ln -sf ~/dotfiles/.zshenv ~/.zshenv
 ln -sf ~/dotfiles/.zshrc ~/.zshrc
 mkdir -p ~/.docker
 ln -sf ~/dotfiles/misc/docker-config.json ~/.docker/config.json
+mkdir -p ~/.local/state/crossnote
+ln -sf ~/dotfiles/misc/crossnote/parser.js ~/.local/state/crossnote/parser.js
+ln -sf ~/dotfiles/misc/crossnote/style.less ~/.local/state/crossnote/style.less
 
 # ssh config
 if [ ! -d ${HOME}/.ssh ]; then

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -27,7 +27,7 @@
   // ===================
   // Workbench
   // ===================
-  "workbench.colorTheme": "Quiet Light",
+  "workbench.colorTheme": "Cursor Light",
   "workbench.startupEditor": "newUntitledFile",
   "workbench.editor.wrapTabs": true,
   "workbench.sideBar.location": "left",

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -27,7 +27,7 @@
   // ===================
   // Workbench
   // ===================
-  "workbench.colorTheme": "Cursor Light",
+  "workbench.colorTheme": "Quiet Light",
   "workbench.startupEditor": "newUntitledFile",
   "workbench.editor.wrapTabs": true,
   "workbench.sideBar.location": "left",


### PR DESCRIPTION
## Summary
- add the Crossnote `parser.js` and `style.less` files under `misc/crossnote` so they are tracked in dotfiles
- update `scripts/deploy.sh` to create `~/.local/state/crossnote` and symlink both files into place
- document the managed Crossnote config in `misc/README.md`

## Test plan
- [x] Run `~/dotfiles/scripts/deploy.sh`
- [x] Confirm `~/.local/state/crossnote/parser.js` points to `~/dotfiles/misc/crossnote/parser.js`
- [x] Confirm `~/.local/state/crossnote/style.less` points to `~/dotfiles/misc/crossnote/style.less`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Crossnote カスタムパーサー機能を追加。メモ、警告、情報などのCallout構文に対応し、HTMLに自動変換します。
  * Calloutブロック用のカスタムスタイルシートを導入。プレビュー表示とPDF出力のビジュアルをカスタマイズできます。

* **ドキュメント**
  * Crossnote設定に関する新しいドキュメンテーションセクションを追加しました。

* **その他**
  * デプロイスクリプトを更新。必要なCrossnote設定ファイルを自動配置するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->