### PR TITLE
move PATH construction to .zprofile to dodge macOS path_helper

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -1,0 +1,26 @@
+# ~/.zprofile — login-time setup
+# Runs after macOS /etc/zprofile's path_helper, so PATH ordering set here wins.
+
+# Inherit prezto defaults (base path, less options, editors, etc.)
+[[ -s ${ZDOTDIR:-$HOME}/.zprezto/runcoms/zprofile ]] && \
+  source "${ZDOTDIR:-$HOME}/.zprezto/runcoms/zprofile"
+
+# Project-specific PATH (prepended → highest priority)
+if [[ $OSTYPE == darwin* ]]; then
+  path=(
+    ~/.antigravity/antigravity/bin
+    $HOMEBREW_PREFIX/opt/ruby/bin
+    $HOMEBREW_PREFIX/bin
+    $path
+  )
+fi
+
+path=(
+  $GOPATH/bin
+  $DOTFILES/bin(N)
+  $DOTFILES/bin/private(N)
+  $path
+)
+
+typeset -gU path
+export PATH

--- a/.zshenv
+++ b/.zshenv
@@ -1,43 +1,33 @@
-# ~/.zshenv — environment variables for all shells
+# ~/.zshenv — environment variables for all zsh shells (kept minimal).
+# PATH is built in ~/.zprofile, not here, so script invocations stay light
+# and macOS path_helper (in /etc/zprofile) cannot reorder our PATH.
 
-# 1) Non-login shell: source .zprofile once
-if [[ ($SHLVL -eq 1 && ! -o LOGIN) && -s ${ZDOTDIR:-$HOME}/.zprofile ]]; then
-  source "${ZDOTDIR:-$HOME}/.zprofile"
-fi
-
-# 2) Core environment
+# Core environment
 export DOTFILES="$HOME/dotfiles"
 export EDITOR='vim'
 export VISUAL='vim'
 export PAGER='less'
 export GOPATH="$DOTFILES/pkg/go"
 
-# 3) AWS
+# AWS
 export AWS_DEFAULT_REGION='ap-northeast-1'
 export AWS_ASSUME_ROLE_TTL='12h'
 export AWS_SESSION_TOKEN_TTL='12h'
 
-# 4) Locale
+# Locale
 [[ -z $LANG ]] && eval "$(locale)"
 
-# 5) OS-specific settings
+# OS-specific env (PATH lives in .zprofile)
 if [[ $OSTYPE == darwin* ]]; then
   export BROWSER='open'
   typeset -g HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-/opt/homebrew}"
-
-  path=(
-    ~/.antigravity/antigravity/bin
-    $HOMEBREW_PREFIX/opt/ruby/bin
-    $HOMEBREW_PREFIX/bin
-    $path
-  )
 elif [[ $OSTYPE == linux-gnu* && -n $WSL_DISTRO_NAME ]]; then
   export BROWSER='wslview'
 fi
 
-# 6) Common PATH additions
-path=("$GOPATH/bin" $path)
-
-# Deduplicate
-typeset -gU path
-export PATH
+# Non-login shells (e.g. `exec zsh`) skip /etc/zprofile and ~/.zprofile,
+# so source ~/.zprofile manually to keep PATH consistent across both modes.
+# Guarded by SHLVL to avoid re-sourcing in nested shells.
+if [[ ($SHLVL -eq 1 && ! -o LOGIN) && -s ${ZDOTDIR:-$HOME}/.zprofile ]]; then
+  source "${ZDOTDIR:-$HOME}/.zprofile"
+fi

--- a/.zshrc
+++ b/.zshrc
@@ -32,14 +32,7 @@ for f in common docker-aliases extra functions http-status-codes; do
   [[ -f $DOTFILES/zsh/$f.zsh ]] && source $DOTFILES/zsh/$f.zsh
 done
 
-# PATH additions
-[[ -d $DOTFILES/bin ]] && addToPath $DOTFILES/bin
-[[ -d $DOTFILES/bin/private ]] && addToPath $DOTFILES/bin/private
-
 # Docker completions
 fpath=(~/.docker/completions $fpath)
 autoload -Uz compinit
 compinit
-
-# Added by Antigravity
-export PATH="/Users/shun.tagami/.antigravity/antigravity/bin:$PATH"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -28,7 +28,7 @@ fi
 
 # prezto
 setopt EXTENDED_GLOB
-for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^(README.md|zpreztorc|zshenv|zshrc)(.N); do
+for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^(README.md|zpreztorc|zshenv|zshrc|zprofile)(.N); do
   ln -sf "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
 done
 
@@ -41,6 +41,7 @@ ln -sf ~/dotfiles/.gitconfig ~/.gitconfig
 ln -sf ~/dotfiles/.gitignore_global ~/.gitignore_global
 ln -sf ~/dotfiles/.vimrc ~/.vimrc
 ln -sf ~/dotfiles/.zpreztorc ~/.zpreztorc
+ln -sf ~/dotfiles/.zprofile ~/.zprofile
 ln -sf ~/dotfiles/.zshenv ~/.zshenv
 ln -sf ~/dotfiles/.zshrc ~/.zshrc
 mkdir -p ~/.docker


### PR DESCRIPTION
## Summary
- New terminals were resolving `/usr/bin/ruby` (system 2.6) instead of the brew-installed ruby. `exec zsh` worked because non-login shells skip `/etc/zprofile`'s `path_helper`, but a fresh login shell had path_helper reorder PATH between `.zshenv` and `.zshrc`, pushing `/usr/bin` ahead of Homebrew paths.
- Move PATH construction into `~/.zprofile` so it runs **after** `path_helper`, making the ordering issue structurally impossible. `.zshenv` is now env-vars only and stays light for non-interactive script invocations.
- The non-login fallback in `.zshenv` (existing `SHLVL` guard) sources `.zprofile` so `exec zsh` keeps working without duplication.

## Changes
- **new** `.zprofile`: sources prezto's zprofile then prepends project-specific paths (antigravity, brew ruby, brew bin, GOPATH, dotfiles bin)
- **`.zshenv`**: drop the path block; keep env vars only; move the non-login `.zprofile` source to the bottom (so `$DOTFILES`/`$GOPATH` are exported before it runs)
- **`.zshrc`**: drop `addToPath $DOTFILES/bin` lines (now in `.zprofile`) and the duplicate Antigravity `export PATH` at the end
- **`scripts/deploy.sh`**: exclude `zprofile` from the prezto runcoms symlink loop and add an explicit symlink to `~/dotfiles/.zprofile`

## Test plan
- [x] `zsh -l -c 'which ruby'` → `/opt/homebrew/opt/ruby/bin/ruby`
- [x] `zsh -l -c 'ruby -v'` → 4.0.3 (brew)
- [x] `~/.zprofile` symlink updated locally
- [ ] Open a fresh terminal window after merge — `which ruby` should resolve to brew without needing `exec zsh`
- [ ] `exec zsh` (non-login) still resolves PATH correctly via the SHLVL fallback in `.zshenv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)