### PR TITLE
worktree: extract helpers to bin/ and tighten design

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -88,16 +88,8 @@
 
 	show-merge = "!sh -c 'merge=$(git find-merge $0 $1) && [ -n \"$merge\" ] && git show $merge'"
 
-	# ===== Unified worktree entrypoint =====
-	# git w <branch> : ../repo-<branch> に worktree 作成 or 既存案内
-	# git w <number> : PR #<number> 用に ../repo-pr-<number> を作成 or 既存案内
-	w = "!f() { arg=\"$1\"; repo=$(basename \"$(pwd)\"); if [ -z \"$arg\" ]; then echo 'usage: git w <branch-or-pr-number>'; exit 1; fi; if printf '%s' \"$arg\" | grep -Eq '^[0-9]+$'; then pr=\"$arg\"; branch=$(gh pr view \"$pr\" --json headRefName -q .headRefName 2>/dev/null); if [ -z \"$branch\" ]; then echo \"[git w] Error: cannot fetch PR #$pr\"; exit 1; fi; workdir=\"../$repo-pr-$pr\"; localbranch=\"pr-$pr\"; if [ -d \"$workdir\" ]; then echo \"[git w] worktree already exists:\"; echo \"  cd $workdir\"; exit 0; fi; echo \"[git w] creating PR worktree for #$pr (branch: $branch)...\"; git fetch origin \"$branch\":\"$localbranch\" --update-head-ok; git worktree add \"$workdir\" \"$localbranch\"; echo \"  cd $workdir\"; exit 0; fi; branch=\"$arg\"; workdir=\"../$repo-$branch\"; if [ -d \"$workdir\" ]; then echo \"[git w] worktree already exists:\"; echo \"  cd $workdir\"; exit 0; fi; default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'); if ! git rev-parse --verify \"$branch\" >/dev/null 2>&1; then git branch \"$branch\" \"origin/$default_branch\"; fi; echo \"[git w] creating worktree for branch '$branch'...\"; git worktree add \"$workdir\" \"$branch\"; echo \"  cd $workdir\"; }; f"
-
-	# List worktrees in a compact table
-	wl = "!f() { echo 'PATH\\tBRANCH\\tHEAD'; git worktree list --porcelain | awk '/^worktree/ {path=$2} /^branch/ {gsub(\"refs/heads/\", \"\", $2); branch=$2} /^HEAD/ {head=$2} /^$/ {printf \"%s\\t%s\\t%s\\n\", path, branch, head}'; }; f"
-
-	# Delete worktree + local branch (PR number or branch name)
-	wd = "!f() { arg=\"$1\"; repo=$(basename \"$(pwd)\"); if [ -z \"$arg\" ]; then echo 'usage: git wd <branch-or-pr-number>'; exit 1; fi; if printf '%s' \"$arg\" | grep -Eq '^[0-9]+$'; then pr=\"$arg\"; branch=\"pr-$pr\"; workdir=\"../$repo-pr-$pr\"; else branch=\"$arg\"; workdir=\"../$repo-$branch\"; fi; if [ ! -d \"$workdir\" ]; then echo \"[git wd] no such worktree dir: $workdir\"; exit 1; fi; echo \"[git wd] removing worktree: $workdir\"; git worktree remove \"$workdir\" || exit 1; if git rev-parse --verify \"$branch\" >/dev/null 2>&1; then echo \"[git wd] deleting branch '$branch'\"; git branch -D \"$branch\"; else echo \"[git wd] branch '$branch' not found (maybe already deleted)\"; fi; }; f"
+	# Worktree helpers: `git w`, `git wl`, `git wd` are implemented as
+	# scripts in $DOTFILES/bin (auto-discovered via PATH).
 
 	empty-push = "!f() { branch=$(git branch --show-current); git commit --allow-empty -m \"empty commit for deploy\" && git push origin $branch; }; f"
 

--- a/bin/git-w
+++ b/bin/git-w
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# git w <branch>     : create worktree at ../<repo>-<sanitized-branch>
+# git w <pr-number>  : create worktree at ../<repo>-pr-<N> tracking the PR's head branch
+#
+# Notes:
+#   - Worktree path lives next to the main checkout (parent of main worktree).
+#   - For branch mode: fetches origin/<default> first so new branches start from latest.
+#   - For PR mode: uses the PR's actual branch name locally and configures upstream
+#     tracking the same way `gh pr checkout` does, so `git push` from the worktree
+#     pushes back to the PR.
+#   - Refuses to create a worktree for the repository's default branch.
+
+set -euo pipefail
+
+usage() {
+  echo 'usage: git w <branch-or-pr-number>' >&2
+  exit 1
+}
+
+[[ $# -eq 1 ]] || usage
+arg="$1"
+
+main_worktree=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+if [[ -z "$main_worktree" ]]; then
+  echo '[git w] could not determine main worktree' >&2
+  exit 1
+fi
+repo=$(basename "$main_worktree")
+parent=$(dirname "$main_worktree")
+
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || true)
+
+if [[ "$arg" =~ ^[0-9]+$ ]]; then
+  pr="$arg"
+  branch=$(gh pr view "$pr" --json headRefName -q .headRefName 2>/dev/null || true)
+  if [[ -z "$branch" ]]; then
+    echo "[git w] Error: cannot fetch PR #$pr" >&2
+    exit 1
+  fi
+
+  workdir="$parent/$repo-pr-$pr"
+  if [[ -d "$workdir" ]]; then
+    echo "[git w] worktree already exists:"
+    echo "  cd $workdir"
+    exit 0
+  fi
+
+  echo "[git w] creating PR worktree for #$pr (branch: $branch)..."
+  # Fetch into local branch with the original name so push refspecs line up.
+  git fetch origin "$branch:$branch" --update-head-ok
+  git worktree add "$workdir" "$branch"
+
+  # Configure upstream the same way `gh pr checkout` does.
+  git -C "$workdir" config "branch.$branch.remote" origin
+  git -C "$workdir" config "branch.$branch.merge" "refs/heads/$branch"
+
+  echo "  cd $workdir"
+  exit 0
+fi
+
+branch="$arg"
+sanitized=${branch//\//-}
+workdir="$parent/$repo-$sanitized"
+
+if [[ -n "$default_branch" && "$branch" == "$default_branch" ]]; then
+  echo "[git w] refusing to create a worktree for the default branch '$branch'." >&2
+  echo "[git w] the main checkout already tracks it: $main_worktree" >&2
+  exit 1
+fi
+
+if [[ -d "$workdir" ]]; then
+  echo "[git w] worktree already exists:"
+  echo "  cd $workdir"
+  exit 0
+fi
+
+if [[ -n "$default_branch" ]]; then
+  echo "[git w] fetching origin/$default_branch..."
+  git fetch origin "$default_branch" >/dev/null
+fi
+
+if ! git rev-parse --verify "$branch" >/dev/null 2>&1; then
+  if [[ -z "$default_branch" ]]; then
+    echo "[git w] cannot determine default branch to base '$branch' on" >&2
+    exit 1
+  fi
+  git branch "$branch" "origin/$default_branch"
+fi
+
+echo "[git w] creating worktree for branch '$branch'..."
+git worktree add "$workdir" "$branch"
+echo "  cd $workdir"

--- a/bin/git-wd
+++ b/bin/git-wd
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# git wd <branch-or-pr-number> : remove worktree at ../<repo>-<sanitized> + delete its branch.
+#
+# Refuses to:
+#   - delete a worktree for the repository's default branch
+#   - delete the worktree the caller is currently inside (use `gwd` zsh wrapper
+#     to auto-cd out first, or cd out manually)
+
+set -euo pipefail
+
+usage() {
+  echo 'usage: git wd <branch-or-pr-number>' >&2
+  exit 1
+}
+
+[[ $# -eq 1 ]] || usage
+arg="$1"
+
+main_worktree=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+if [[ -z "$main_worktree" ]]; then
+  echo '[git wd] could not determine main worktree' >&2
+  exit 1
+fi
+repo=$(basename "$main_worktree")
+parent=$(dirname "$main_worktree")
+
+if [[ "$arg" =~ ^[0-9]+$ ]]; then
+  workdir="$parent/$repo-pr-$arg"
+else
+  sanitized=${arg//\//-}
+  workdir="$parent/$repo-$sanitized"
+fi
+
+if [[ ! -d "$workdir" ]]; then
+  echo "[git wd] no such worktree dir: $workdir" >&2
+  exit 1
+fi
+
+branch=$(git -C "$workdir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || true)
+if [[ -n "$default_branch" && "$branch" == "$default_branch" ]]; then
+  echo "[git wd] refusing to delete worktree on default branch '$branch'." >&2
+  exit 1
+fi
+
+current_toplevel=$(git rev-parse --show-toplevel 2>/dev/null || true)
+workdir_abs=$(cd "$workdir" && pwd)
+if [[ -n "$current_toplevel" && "$current_toplevel" == "$workdir_abs" ]]; then
+  echo "[git wd] refusing to delete the worktree you are currently in: $workdir_abs" >&2
+  echo "[git wd] cd elsewhere (e.g. cd $main_worktree) and retry, or use the gwd zsh wrapper." >&2
+  exit 1
+fi
+
+echo "[git wd] removing worktree: $workdir"
+git worktree remove "$workdir"
+
+if [[ -n "$branch" ]] && git rev-parse --verify "$branch" >/dev/null 2>&1; then
+  echo "[git wd] deleting branch '$branch'"
+  git branch -D "$branch"
+else
+  echo "[git wd] branch '$branch' not found (maybe already deleted)"
+fi

--- a/bin/git-wl
+++ b/bin/git-wl
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# git wl : list worktrees in a compact PATH / BRANCH / HEAD table.
+
+set -euo pipefail
+
+printf 'PATH\tBRANCH\tHEAD\n'
+git worktree list --porcelain | awk '
+  /^worktree /   { path = $2 }
+  /^branch /     { sub("refs/heads/", "", $2); branch = $2 }
+  /^HEAD /       { head = $2 }
+  /^detached$/   { branch = "(detached)" }
+  /^$/           { printf "%s\t%s\t%s\n", path, branch, head; branch = ""; head = "" }
+  END            { if (path != "" && head != "") printf "%s\t%s\t%s\n", path, branch, head }
+'

--- a/zsh/functions.zsh
+++ b/zsh/functions.zsh
@@ -277,35 +277,70 @@ gw() {
     return 1
   fi
 
-  local origdir="$PWD"
-  local output
+  # Source for .env copies is the main worktree, not necessarily $PWD —
+  # this lets `gw` work when invoked from inside an existing linked worktree.
+  local source_root
+  source_root=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+  if [[ -z "$source_root" ]]; then
+    source_root="$PWD"
+  fi
+
+  local output rc
   output=$(git w "$@" 2>&1)
-  local rc=$?
+  rc=$?
 
   echo "$output"
   if [[ $rc -ne 0 ]]; then
     return $rc
   fi
 
-  # Extract workdir path from "  cd <path>" line in git w output
   local workdir
   workdir=$(echo "$output" | sed -n 's/^  cd //p')
 
   if [[ -n "$workdir" && -d "$workdir" ]]; then
-    # Copy .env* files from original repo to new worktree
-    local copied=0
-    for envfile in "$origdir"/.env*; do
-      if [[ -f "$envfile" ]]; then
-        cp "$envfile" "$workdir/"
-        copied=$((copied + 1))
-      fi
-    done
+    local copied=0 envfile rel dest
+    while IFS= read -r envfile; do
+      rel="${envfile#$source_root/}"
+      dest="$workdir/$rel"
+      mkdir -p "$(dirname "$dest")"
+      cp "$envfile" "$dest"
+      copied=$((copied + 1))
+    done < <(find "$source_root" \
+        \( -name node_modules -o -name .git -o -name dist -o -name build \
+           -o -name .next -o -name target -o -name vendor -o -name .venv \) -prune -o \
+        -type f \( -name '.env' -o -name '.env.*' \) -print)
+
     if (( copied > 0 )); then
       echo "[gw] copied $copied .env file(s) to $workdir"
     fi
 
     cd "$workdir"
   fi
+}
+
+# Companion to gw: delete a worktree + its branch. If invoked from inside a
+# linked worktree, cd back to the main worktree first so `git wd`'s relative
+# resolution is correct and `git worktree remove` cannot evict the caller.
+# Usage: gwd <branch-or-pr-number>
+gwd() {
+  if [[ -z "$1" ]]; then
+    echo 'usage: gwd <branch-or-pr-number>'
+    return 1
+  fi
+
+  local toplevel main_worktree
+  toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo '[gwd] not inside a git repository'
+    return 1
+  }
+  main_worktree=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+
+  if [[ -n "$main_worktree" && "$main_worktree" != "$toplevel" ]]; then
+    echo "[gwd] cd to main worktree: $main_worktree"
+    cd "$main_worktree" || return 1
+  fi
+
+  git wd "$@"
 }
 
 alias ggrep="git grep -A 5 -B 5"


### PR DESCRIPTION
## Summary

- `git w` / `git wl` / `git wd` のインライン .gitconfig 一行スクリプトを `bin/` 配下のシェルスクリプトに抽出（PATH 経由で git が自動検出）。
- AI 並列実行ワークフロー向けに 6 つの運用ギャップを解消：
  - `gw` の対になる `gwd` を新設（linked worktree からも安全に削除）
  - 新規ブランチ作成時に `origin/<default>` を fetch
  - ブランチ名の `/` を worktree path で `-` に正規化
  - `.env*` コピーを再帰化（重い/システム系ディレクトリは prune）
  - PR worktree のローカルブランチを元のブランチ名に変更＋tracking 設定で `git push` がそのまま PR に戻る（`gh pr checkout` 同等）
  - default branch / 自分が居る worktree への `git wd` を拒否

## Test plan

- [x] `bash -n` / `zsh -n` で全スクリプトを syntax check
- [x] `git wl` で worktree 一覧表示確認
- [x] `git w` / `git wd` の usage / default-branch 拒否を確認
- [ ] 別リポジトリで `gw <branch>` → worktree 作成 + `.env*` 再帰コピー + `cd` を実機確認
- [ ] `gw <PR#>` → `git push` で元の PR ブランチに戻ることを確認
- [ ] linked worktree 内で `gwd <other>` 実行時にメインへ自動 cd することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * Git worktreeコマンド（`git w`、`git wl`、`git wd`）がエイリアスからスタンドアロンスクリプトに移行

* **New Features**
  * `git w`：プルリクエスト番号またはブランチ名を指定してworktreeを作成
  * `git wl`：worktreeの一覧表示
  * `git wd`：worktreeとその関連ブランチを削除
  * worktree作成時に`.env`ファイルの自動コピー機能を追加
  * worktree削除時の便利なヘルパーコマンドを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shuntagami/dotfiles/pull/85)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->