### PR TITLE
worktree: add git wclean and gwp (promote uncommitted to worktree)

### DIFF
--- a/bin/git-wclean
+++ b/bin/git-wclean
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# git wclean : remove linked worktrees whose branches were merged or whose
+#              upstream has been deleted (typical after `gh pr merge --delete-branch`).
+#
+# Flags:
+#   --dry-run   show what would be removed, don't touch anything
+#   -y / --yes  skip the interactive confirmation
+#
+# Safety:
+#   - never touches the main worktree or the worktree the caller is in
+#   - skips worktrees with uncommitted changes (reported, not deleted)
+#   - refuses to delete the default branch
+
+set -euo pipefail
+
+dry_run=0
+assume_yes=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) dry_run=1 ;;
+    -y|--yes)  assume_yes=1 ;;
+    -h|--help)
+      sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "[git wclean] unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+main_worktree=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+if [[ -z "$main_worktree" ]]; then
+  echo '[git wclean] could not determine main worktree' >&2
+  exit 1
+fi
+
+current_toplevel=$(git rev-parse --show-toplevel 2>/dev/null || true)
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || true)
+
+echo "[git wclean] fetching --prune origin..."
+git -C "$main_worktree" fetch --prune origin >/dev/null
+
+# Collect candidate worktrees + their branches.
+# Layout from porcelain: blocks separated by blank lines, each starting with `worktree <path>`.
+# We skip the main worktree, the caller's worktree, detached HEADs, and the default branch.
+
+worktree_paths=()
+while IFS= read -r line; do worktree_paths+=("$line"); done < <(git worktree list --porcelain | awk '/^worktree /{print $2}')
+
+# Pre-compute branches whose upstream is gone.
+gone_upstream=$(git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads/ | awk '$2=="[gone]"{print $1}' || true)
+
+# Pre-compute branches merged into the default branch.
+merged_branches=""
+if [[ -n "$default_branch" ]]; then
+  merged_branches=$(git branch --format='%(refname:short)' --merged "origin/$default_branch" 2>/dev/null | grep -vx "$default_branch" || true)
+fi
+
+declare -a to_remove=()
+declare -a to_remove_branches=()
+declare -a to_remove_reasons=()
+declare -a skipped=()
+
+for wt in "${worktree_paths[@]}"; do
+  if [[ "$wt" == "$main_worktree" ]]; then
+    continue
+  fi
+  if [[ -n "$current_toplevel" && "$wt" == "$current_toplevel" ]]; then
+    skipped+=("$wt :: current worktree (cd elsewhere first)")
+    continue
+  fi
+  branch=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
+  if [[ "$branch" == "HEAD" ]]; then
+    continue
+  fi
+  if [[ -n "$default_branch" && "$branch" == "$default_branch" ]]; then
+    continue
+  fi
+
+  reason=""
+  if grep -qx "$branch" <<<"$gone_upstream" 2>/dev/null; then
+    reason="upstream gone"
+  elif [[ -n "$merged_branches" ]] && grep -qx "$branch" <<<"$merged_branches" 2>/dev/null; then
+    reason="merged into $default_branch"
+  fi
+
+  if [[ -z "$reason" ]]; then
+    continue
+  fi
+
+  if [[ -n "$(git -C "$wt" status --porcelain 2>/dev/null)" ]]; then
+    skipped+=("$wt ($branch) :: uncommitted changes")
+    continue
+  fi
+
+  to_remove+=("$wt")
+  to_remove_branches+=("$branch")
+  to_remove_reasons+=("$reason")
+done
+
+if (( ${#to_remove[@]} == 0 )); then
+  echo "[git wclean] nothing to clean."
+  if (( ${#skipped[@]} > 0 )); then
+    printf '[git wclean] skipped:\n'
+    printf '  %s\n' "${skipped[@]}"
+  fi
+  exit 0
+fi
+
+echo "[git wclean] candidates:"
+for i in "${!to_remove[@]}"; do
+  printf '  %s (%s) :: %s\n' "${to_remove[$i]}" "${to_remove_branches[$i]}" "${to_remove_reasons[$i]}"
+done
+if (( ${#skipped[@]} > 0 )); then
+  printf '[git wclean] skipped:\n'
+  printf '  %s\n' "${skipped[@]}"
+fi
+
+if (( dry_run )); then
+  echo "[git wclean] dry-run: no changes made."
+  exit 0
+fi
+
+if (( ! assume_yes )); then
+  printf '[git wclean] proceed? [y/N] '
+  read -r reply
+  case "$reply" in
+    y|Y|yes|YES) ;;
+    *) echo '[git wclean] aborted.'; exit 0 ;;
+  esac
+fi
+
+for i in "${!to_remove[@]}"; do
+  wt="${to_remove[$i]}"
+  branch="${to_remove_branches[$i]}"
+  echo "[git wclean] removing worktree: $wt"
+  if git -C "$main_worktree" worktree remove "$wt"; then
+    if git -C "$main_worktree" rev-parse --verify "$branch" >/dev/null 2>&1; then
+      echo "[git wclean] deleting branch: $branch"
+      git -C "$main_worktree" branch -D "$branch"
+    fi
+  else
+    echo "[git wclean] failed to remove $wt (skipping branch deletion)" >&2
+  fi
+done
+
+# Tidy administrative records of any orphan worktrees (dirs deleted manually, etc.)
+git -C "$main_worktree" worktree prune
+echo "[git wclean] done."

--- a/zsh/functions.zsh
+++ b/zsh/functions.zsh
@@ -318,6 +318,90 @@ gw() {
   fi
 }
 
+# Promote uncommitted work in the main worktree to a fresh worktree.
+# Useful when you started Claude/coding directly in the main checkout and
+# realized you want isolation. Stashes (incl. untracked), creates the
+# worktree, pops the stash there, and copies the latest Claude session
+# jsonl so `claude --resume` in the new worktree shows the conversation.
+# Usage: gwp <branch-or-pr-number>
+gwp() {
+  if [[ -z "$1" ]]; then
+    echo 'usage: gwp <branch-or-pr-number>'
+    return 1
+  fi
+
+  local toplevel main_worktree
+  toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo '[gwp] not inside a git repository'
+    return 1
+  }
+  main_worktree=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+
+  if [[ "$toplevel" != "$main_worktree" ]]; then
+    echo "[gwp] must be run from the main worktree ($main_worktree)" >&2
+    echo "[gwp] you are in: $toplevel" >&2
+    return 1
+  fi
+
+  if [[ -z "$(git status --porcelain)" ]]; then
+    echo "[gwp] no uncommitted changes to promote; use 'gw' instead" >&2
+    return 1
+  fi
+
+  local source_dir="$toplevel"
+  local stash_msg="gwp: promote to worktree '$1'"
+
+  echo "[gwp] stashing uncommitted changes (including untracked)..."
+  if ! git stash push -u -m "$stash_msg" >/dev/null; then
+    echo '[gwp] stash failed' >&2
+    return 1
+  fi
+
+  local output rc workdir
+  output=$(git w "$@" 2>&1)
+  rc=$?
+  echo "$output"
+  if [[ $rc -ne 0 ]]; then
+    echo '[gwp] worktree creation failed; restoring stash' >&2
+    git stash pop >/dev/null 2>&1
+    return $rc
+  fi
+  workdir=$(echo "$output" | sed -n 's/^  cd //p')
+  if [[ -z "$workdir" || ! -d "$workdir" ]]; then
+    echo '[gwp] could not determine new worktree path; restoring stash' >&2
+    git stash pop >/dev/null 2>&1
+    return 1
+  fi
+
+  cd "$workdir" || return 1
+
+  echo "[gwp] applying stash in $workdir..."
+  if ! git stash pop; then
+    echo '[gwp] stash pop had conflicts — resolve manually (stash entry preserved)' >&2
+  fi
+
+  # Copy the most recent Claude Code session jsonl to the new project dir so
+  # `claude --resume` here can pick up the conversation. Encoding: `/` and `.`
+  # in the cwd both become `-` in the project dir name.
+  local encoded_source encoded_target src_proj dst_proj latest
+  encoded_source=$(printf '%s' "$source_dir" | tr '/.' '--')
+  encoded_target=$(printf '%s' "$workdir"   | tr '/.' '--')
+  src_proj="$HOME/.claude/projects/$encoded_source"
+  dst_proj="$HOME/.claude/projects/$encoded_target"
+
+  if [[ -d "$src_proj" ]]; then
+    latest=$(ls -t "$src_proj"/*.jsonl 2>/dev/null | head -1)
+    if [[ -n "$latest" ]]; then
+      mkdir -p "$dst_proj"
+      cp "$latest" "$dst_proj/"
+      echo "[gwp] copied Claude session: $(basename "$latest")"
+      echo "[gwp] resume here with:  claude --resume"
+    else
+      echo "[gwp] no Claude session jsonl found in $src_proj"
+    fi
+  fi
+}
+
 # Companion to gw: delete a worktree + its branch. If invoked from inside a
 # linked worktree, cd back to the main worktree first so `git wd`'s relative
 # resolution is correct and `git worktree remove` cannot evict the caller.


### PR DESCRIPTION
## Summary

#85 のフォローアップ。AI 並列開発フローで残っていた 2 つの摩擦に対応：

### `git wclean` — マージ後のお片付け

`gh pr merge --delete-branch` の後にローカルに残る worktree / ブランチを自動掃除：
- upstream gone（リモート削除済み）と default branch にマージ済みの両方を検出
- `--dry-run` で確認、`-y` で確認スキップ
- uncommitted changes / default branch / 自分が居る worktree は除外

### `gwp <branch>` — main で作業し始めちゃった時の救済

\"worktree 切らずに Claude Code で作業開始 → 後から isolation 欲しくなる\" 問題に対応：
1. 未コミット変更を未追跡含めて stash
2. `git w <branch>` で新 worktree 作成
3. stash を新 worktree に pop
4. 直近の Claude session jsonl を新 project ディレクトリ (\`~/.claude/projects/<encoded-cwd>/\`) にコピー
5. 新 worktree で \`claude --resume\` すると会話履歴ごと続行できる

## Test plan

- [x] `bash -n` / `zsh -n` syntax check
- [x] `git wclean --dry-run` 実行（dotfiles に linked worktree なしの状態で no-op を確認）
- [ ] 実 worktree でマージ後 `git wclean` 実行
- [ ] main で uncommitted 状態から `gwp <branch>` → stash 移送 + session コピー確認
- [ ] 新 worktree で `claude --resume` から前セッションが見えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)