### PR TITLE
Enable Touch ID for sudo

### DIFF
--- a/misc/Brewfile
+++ b/misc/Brewfile
@@ -90,6 +90,7 @@ brew "pngpaste"
 brew "poppler"
 brew "qt@5"
 brew "poppler-qt5"
+brew "pam-reattach"
 brew "portaudio"
 brew "postgresql@14", restart_service: :changed
 brew "pstree"

--- a/scripts/macos.sh
+++ b/scripts/macos.sh
@@ -16,6 +16,8 @@ sudo -v
 # Keep-alive: update existing `sudo` time stamp until `.macos` has finished
 while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
 
+bash "${HOME}/dotfiles/scripts/sudo-touch-id.sh"
+
 ###############################################################################
 # General UI/UX                                                               #
 ###############################################################################

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,6 +41,11 @@ echo "==> Deploying dotfiles..."
 zsh "${DOTFILES}/scripts/deploy.sh"
 
 # Phase 3: macOS / editor settings (macOS only)
+if [[ "$(uname)" == "Darwin" ]]; then
+  echo "==> Configuring sudo Touch ID..."
+  bash "${DOTFILES}/scripts/sudo-touch-id.sh"
+fi
+
 # if [[ "$(uname)" == "Darwin" ]]; then
   # echo "==> Configuring macOS defaults..."
   # bash "${DOTFILES}/scripts/macos.sh"

--- a/scripts/sudo-touch-id.sh
+++ b/scripts/sudo-touch-id.sh
@@ -16,11 +16,11 @@ block_begin="# dotfiles: begin sudo Touch ID"
 block_end="# dotfiles: end sudo Touch ID"
 brew_prefix=""
 reattach_module=""
-auth_block=""
+auth_block_file="$(mktemp)"
 existing_config="$(mktemp)"
 new_config="$(mktemp)"
 
-trap 'rm -f "${existing_config}" "${new_config}"' EXIT
+trap 'rm -f "${auth_block_file}" "${existing_config}" "${new_config}"' EXIT
 
 if command -v brew >/dev/null 2>&1; then
   brew_prefix="$(brew --prefix 2>/dev/null || true)"
@@ -30,14 +30,14 @@ if [[ -n "${brew_prefix}" ]]; then
   reattach_module="${brew_prefix}/lib/pam/pam_reattach.so"
 fi
 
-auth_block="${block_begin}"$'\n'
+printf '%s\n' "${block_begin}" > "${auth_block_file}"
 if [[ -n "${reattach_module}" && -f "${reattach_module}" ]]; then
-  auth_block+="auth       optional       ${reattach_module} ignore_ssh"$'\n'
+  printf 'auth       optional       %s ignore_ssh\n' "${reattach_module}" >> "${auth_block_file}"
 else
   echo "Skipping pam_reattach: install pam-reattach to make Touch ID work inside tmux/screen."
 fi
-auth_block+="auth       sufficient     pam_tid.so"$'\n'
-auth_block+="${block_end}"
+printf 'auth       sufficient     pam_tid.so\n' >> "${auth_block_file}"
+printf '%s\n' "${block_end}" >> "${auth_block_file}"
 
 if [[ -f "${sudo_local}" ]]; then
   awk -v block_begin="${block_begin}" -v block_end="${block_end}" '
@@ -57,10 +57,17 @@ else
   echo "# sudo_local: local config file which survives system update and is included for sudo" > "${existing_config}"
 fi
 
-awk -v auth_block="${auth_block}" '
+awk -v auth_block_file="${auth_block_file}" '
+  function print_auth_block(line) {
+    while ((getline line < auth_block_file) > 0) {
+      print line
+    }
+    close(auth_block_file)
+  }
+
   {
     if (!inserted && $0 !~ /^[[:space:]]*(#.*)?$/) {
-      print auth_block
+      print_auth_block()
       print ""
       inserted = 1
     }
@@ -74,7 +81,7 @@ awk -v auth_block="${auth_block}" '
       if (saw_nonempty) {
         print ""
       }
-      print auth_block
+      print_auth_block()
     }
   }
 ' "${existing_config}" > "${new_config}"

--- a/scripts/sudo-touch-id.sh
+++ b/scripts/sudo-touch-id.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "Skipping sudo Touch ID setup: this is not macOS."
+  exit 0
+fi
+
+sudo -v
+
+sudo_file="/etc/pam.d/sudo"
+sudo_local="/etc/pam.d/sudo_local"
+sudo_local_template="/etc/pam.d/sudo_local.template"
+block_begin="# dotfiles: begin sudo Touch ID"
+block_end="# dotfiles: end sudo Touch ID"
+brew_prefix=""
+reattach_module=""
+auth_block=""
+existing_config="$(mktemp)"
+new_config="$(mktemp)"
+
+trap 'rm -f "${existing_config}" "${new_config}"' EXIT
+
+if command -v brew >/dev/null 2>&1; then
+  brew_prefix="$(brew --prefix 2>/dev/null || true)"
+fi
+
+if [[ -n "${brew_prefix}" ]]; then
+  reattach_module="${brew_prefix}/lib/pam/pam_reattach.so"
+fi
+
+auth_block="${block_begin}"$'\n'
+if [[ -n "${reattach_module}" && -f "${reattach_module}" ]]; then
+  auth_block+="auth       optional       ${reattach_module} ignore_ssh"$'\n'
+else
+  echo "Skipping pam_reattach: install pam-reattach to make Touch ID work inside tmux/screen."
+fi
+auth_block+="auth       sufficient     pam_tid.so"$'\n'
+auth_block+="${block_end}"
+
+if [[ -f "${sudo_local}" ]]; then
+  awk -v block_begin="${block_begin}" -v block_end="${block_end}" '
+    $0 == block_begin { skip = 1; next }
+    $0 == block_end { skip = 0; next }
+    skip { next }
+    /^[[:space:]]*#?[[:space:]]*auth[[:space:]]+sufficient[[:space:]]+pam_tid\.so([[:space:]]+.*)?$/ { next }
+    /pam_reattach\.so/ { next }
+    { print }
+  ' "${sudo_local}" > "${existing_config}"
+elif [[ -f "${sudo_local_template}" ]]; then
+  awk '
+    /^[[:space:]]*#?[[:space:]]*auth[[:space:]]+sufficient[[:space:]]+pam_tid\.so([[:space:]]+.*)?$/ { next }
+    { print }
+  ' "${sudo_local_template}" > "${existing_config}"
+else
+  echo "# sudo_local: local config file which survives system update and is included for sudo" > "${existing_config}"
+fi
+
+awk -v auth_block="${auth_block}" '
+  {
+    if (!inserted && $0 !~ /^[[:space:]]*(#.*)?$/) {
+      print auth_block
+      print ""
+      inserted = 1
+    }
+    print
+    if ($0 !~ /^[[:space:]]*$/) {
+      saw_nonempty = 1
+    }
+  }
+  END {
+    if (!inserted) {
+      if (saw_nonempty) {
+        print ""
+      }
+      print auth_block
+    }
+  }
+' "${existing_config}" > "${new_config}"
+
+sudo install -m 644 -o root -g wheel "${new_config}" "${sudo_local}"
+
+if ! grep -Eq '^[[:space:]]*auth[[:space:]]+include[[:space:]]+sudo_local' "${sudo_file}"; then
+  echo "Warning: ${sudo_file} does not include sudo_local, so this macOS version may need manual PAM setup."
+fi
+
+echo "Configured Touch ID for sudo in ${sudo_local}."


### PR DESCRIPTION
## Summary
- add a macOS sudo Touch ID setup script that manages /etc/pam.d/sudo_local
- install pam-reattach through Brewfile for tmux/screen support
- call the setup from setup.sh and macos.sh

## Verification
- bash -n scripts/setup.sh scripts/macos.sh scripts/sudo-touch-id.sh
- git diff --check
- brew list --versions pam-reattach

Note: applying /etc/pam.d/sudo_local still requires interactive sudo on the target Mac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * macOS で sudo コマンドに Touch ID 認証機能を追加しました。これにより、sudo 権限が必要な場合にパスワード入力の代わりに Touch ID で認証できるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shuntagami/dotfiles/pull/88)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->