### PR TITLE
feat(bin): add Google Docs Markdown tools

### DIFF
--- a/bin/gdoc2md
+++ b/bin/gdoc2md
@@ -236,11 +236,11 @@ console.error(`[2/3] Markdown 変換完了: ${bodyMd.length} 文字`);
 // 既存ファイルがあれば diff 表示用に退避
 let diffSummary = "";
 if (localExists) {
-  const oldContent = readFileSync(outPath, "utf8");
-  if (oldContent.trim() === bodyMd.trim()) {
+  const oldBodyMd = extractBodyFromOutput(readFileSync(outPath, "utf8"));
+  if (oldBodyMd.trim() === bodyMd.trim()) {
     diffSummary = "（差分なし）";
   } else {
-    diffSummary = `（差分あり: 旧 ${oldContent.length}字 → 新 ${bodyMd.length}字）`;
+    diffSummary = `（差分あり: 旧 ${oldBodyMd.length}字 → 新 ${bodyMd.length}字）`;
   }
 }
 
@@ -321,6 +321,12 @@ function computeIsStale(docTimeIso, localTimeIso, localExists) {
   // git に commit されていない: 判定不能なので stale 扱い（安全側）
   if (!localTimeIso) return true;
   return new Date(docTimeIso).getTime() > new Date(localTimeIso).getTime();
+}
+
+function extractBodyFromOutput(content) {
+  const marker = "\n---\n\n";
+  const markerIndex = content.indexOf(marker);
+  return markerIndex === -1 ? content : content.slice(markerIndex + marker.length);
 }
 
 function buildOutput({ client, taskTitle, docTitle, docUrl, docModifiedTime, bodyMd, mode }) {

--- a/bin/gdoc2md
+++ b/bin/gdoc2md
@@ -1,0 +1,342 @@
+#!/usr/bin/env -S deno run -A --ext=js
+// @ts-nocheck
+// Google Doc を取り込んで Markdown (.md) に保存する standalone CLI。
+// 鮮度チェック（Doc.modifiedTime vs 既存 .md の git log 時刻）も提供する。
+//
+// Deno で動くため repo 非依存・ローカル node_modules 不要
+// （npm: 依存は Deno のグローバルキャッシュに入る）。
+//
+// Usage:
+//   gdoc2md <google-doc-url> [--out <path>] [--check-only]
+//
+//   URL だけ渡すと、カレントディレクトリに ./<Docタイトル>.md として保存する。
+//   --out を渡せばその場所に保存する。
+//   --check-only は同期せず鮮度チェックの JSON だけ出力する。
+//
+//   （Supabase 経由・タスク名指定の取り込みも一応残してある）
+//   gdoc2md --client <name> --task-title <title> --out <path> [--check-only]
+//   gdoc2md --project-id <uuid> --task-title <title> --out <path> [--check-only]
+//
+// 認証: ~/dotfiles/.env.local の GOOGLE_SERVICE_ACCOUNT_KEY 等を使う。
+//
+// 設計メモ:
+// - 提案モード反映済みの本文を取得（PREVIEW_SUGGESTIONS_ACCEPTED）
+// - viewer 権限しかない Doc では通常モードにフォールバック
+// - Doc → Markdown 変換は ./lib/doc-to-markdown.mjs
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { resolve, dirname, isAbsolute } from "node:path";
+import { homedir } from "node:os";
+import { execSync } from "node:child_process";
+import { docToMarkdown, getDocWithSuggestionFallback, extractDocId } from "./lib/doc-to-markdown.mjs";
+
+// 認証情報は ~/dotfiles/.env.local から読む。
+const ENV_PATH = resolve(homedir(), "dotfiles/.env.local");
+if (!existsSync(ENV_PATH)) {
+  console.error(`.env.local が見つかりません: ${ENV_PATH}`);
+  process.exit(1);
+}
+
+// 外部パッケージ解決: Deno なら npm: 指定、node なら bare specifier。
+const NPM = typeof Deno !== "undefined" ? "npm:" : "";
+
+// =================================================================
+// 引数
+// =================================================================
+
+const args = parseArgs(process.argv.slice(2));
+// URL は --doc-url / --url / 第1位置引数 のいずれでも受け付ける
+const directDocUrl = args["doc-url"] || args.url || args._[0];
+
+// URL を渡せば --out は任意（自動解決）。client / project-id 経由は --task-title と --out が必要。
+const usageAndExit = () => {
+  console.error("Usage:");
+  console.error("  gdoc2md <google-doc-url> [--out <path>] [--check-only]");
+  console.error("  gdoc2md --client <name> --task-title <title> --out <path> [--check-only]");
+  console.error("  gdoc2md --project-id <uuid> --task-title <title> --out <path> [--check-only]");
+  console.error("");
+  console.error("URL だけ渡した場合、--out はカレントディレクトリの ./<Docタイトル>.md になります。");
+  process.exit(2);
+};
+if (!directDocUrl && !args.client && !args["project-id"]) usageAndExit();
+if (!directDocUrl && (!args["task-title"] || !args.out)) usageAndExit();
+
+const checkOnly = !!args["check-only"];
+// --out があれば即解決。無ければ Doc メタ取得後に autoResolveOutPath で決める。
+let outPath = args.out ? (isAbsolute(args.out) ? args.out : resolve(process.cwd(), args.out)) : null;
+
+// =================================================================
+// .env.local 読み込み
+// =================================================================
+
+for (const line of readFileSync(ENV_PATH, "utf8").split("\n")) {
+  const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+  if (!m) continue;
+  let v = m[2];
+  if (v.startsWith('"') && v.endsWith('"')) v = v.slice(1, -1);
+  if (!process.env[m[1]]) process.env[m[1]] = v;
+}
+
+// =================================================================
+// Supabase: project と task の external_url を引く
+// =================================================================
+
+let project;
+let taskTitle = args["task-title"] || "Google Doc";
+let docUrl = directDocUrl;
+
+if (directDocUrl) {
+  project = {
+    id: null,
+    client_name: args.client || "(direct doc url)",
+  };
+} else {
+  const { createClient } = await import(`${NPM}@supabase/supabase-js`);
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+
+  if (args["project-id"]) {
+    const { data, error } = await supabase
+      .from("projects")
+      .select("id, client_name")
+      .eq("id", args["project-id"])
+      .single();
+    if (error || !data) {
+      console.error(`project_id=${args["project-id"]} のプロジェクトが見つかりません`);
+      process.exit(1);
+    }
+    project = data;
+  } else {
+    const { data, error } = await supabase
+      .from("projects")
+      .select("id, client_name")
+      .ilike("client_name", `%${args.client}%`);
+    if (error) {
+      console.error("Supabase error:", error.message);
+      process.exit(1);
+    }
+    if (!data?.length) {
+      console.error(`"${args.client}" にマッチするプロジェクトが見つかりません`);
+      process.exit(1);
+    }
+    if (data.length > 1) {
+      console.error(`"${args.client}" に複数マッチしました。--project-id で指定してください:`);
+      for (const p of data) console.error(`  - ${p.client_name}  (id=${p.id})`);
+      process.exit(1);
+    }
+    project = data[0];
+  }
+
+  const { data: task, error: taskErr } = await supabase
+    .from("tasks")
+    .select("external_url")
+    .eq("project_id", project.id)
+    .eq("title", taskTitle)
+    .maybeSingle();
+
+  if (taskErr) {
+    console.error("Supabase error (tasks):", taskErr.message);
+    process.exit(1);
+  }
+  if (!task?.external_url) {
+    console.error(`${project.client_name} の "${taskTitle}" タスクに external_url が未設定`);
+    process.exit(1);
+  }
+  docUrl = task.external_url;
+}
+
+const docId = extractDocId(docUrl);
+if (!docId) {
+  console.error(`URL から Doc ID を抽出できません: ${docUrl}`);
+  process.exit(1);
+}
+
+// =================================================================
+// Google API auth
+// =================================================================
+
+const { google } = await import(`${NPM}googleapis`);
+const credentials = JSON.parse(
+  process.env.GOOGLE_SERVICE_ACCOUNT_KEY
+    .replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t"),
+);
+const docsAuth = new google.auth.GoogleAuth({
+  credentials,
+  scopes: ["https://www.googleapis.com/auth/documents"],
+  clientOptions: process.env.GOOGLE_IMPERSONATE_EMAIL
+    ? { subject: process.env.GOOGLE_IMPERSONATE_EMAIL }
+    : undefined,
+});
+const driveAuth = new google.auth.GoogleAuth({
+  credentials,
+  scopes: ["https://www.googleapis.com/auth/drive"],
+  clientOptions: process.env.GOOGLE_IMPERSONATE_EMAIL
+    ? { subject: process.env.GOOGLE_IMPERSONATE_EMAIL }
+    : undefined,
+});
+const docs = google.docs({ version: "v1", auth: docsAuth });
+const drive = google.drive({ version: "v3", auth: driveAuth });
+
+// =================================================================
+// 鮮度チェック
+// =================================================================
+
+const docMeta = await drive.files.get({
+  fileId: docId,
+  fields: "id,name,modifiedTime",
+  supportsAllDrives: true,
+});
+const docModifiedTime = docMeta.data.modifiedTime;
+
+// --out 未指定なら ./<Docタイトル>.md に自動決定
+if (!outPath) {
+  outPath = autoResolveOutPath(docMeta.data.name);
+  console.error(`[out] 自動決定: ${outPath}`);
+}
+const localExists = existsSync(outPath);
+const localCommittedTime = localExists ? getLastCommittedTime(outPath) : null;
+const isStale = computeIsStale(docModifiedTime, localCommittedTime, localExists);
+
+if (checkOnly) {
+  const result = {
+    project: { id: project.id, client_name: project.client_name },
+    task_title: taskTitle,
+    doc_url: docUrl,
+    doc_modified_time: docModifiedTime,
+    local_path: outPath,
+    local_exists: localExists,
+    local_git_committed_time: localCommittedTime,
+    is_stale: isStale,
+    stale_by_seconds: localCommittedTime
+      ? Math.max(0, Math.floor((new Date(docModifiedTime).getTime() - new Date(localCommittedTime).getTime()) / 1000))
+      : null,
+  };
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(0);
+}
+
+// =================================================================
+// 取り込み実行
+// =================================================================
+
+console.error(`[1/3] ${project.client_name} の "${taskTitle}" を取得します`);
+console.error(`      ${docUrl}`);
+
+const docResult = await getDocWithSuggestionFallback(docs, docId);
+if (docResult.fallback) {
+  console.error("      ⚠ 提案モードビュー権限なし → 通常モードで取得（提案中の編集は反映されない可能性）");
+}
+const docTitle = docResult.data.title || "(無題)";
+const bodyMd = docToMarkdown(docResult.data);
+
+console.error(`[2/3] Markdown 変換完了: ${bodyMd.length} 文字`);
+
+// 既存ファイルがあれば diff 表示用に退避
+let diffSummary = "";
+if (localExists) {
+  const oldContent = readFileSync(outPath, "utf8");
+  if (oldContent.trim() === bodyMd.trim()) {
+    diffSummary = "（差分なし）";
+  } else {
+    diffSummary = `（差分あり: 旧 ${oldContent.length}字 → 新 ${bodyMd.length}字）`;
+  }
+}
+
+// 出力
+mkdirSync(dirname(outPath), { recursive: true });
+const finalContent = buildOutput({
+  client: project.client_name,
+  taskTitle,
+  docTitle,
+  docUrl,
+  docModifiedTime,
+  bodyMd,
+  mode: docResult.mode,
+});
+writeFileSync(outPath, finalContent);
+
+console.error(`[3/3] 保存: ${outPath} ${diffSummary}`);
+console.log(JSON.stringify({
+  project: { id: project.id, client_name: project.client_name },
+  task_title: taskTitle,
+  doc_url: docUrl,
+  doc_modified_time: docModifiedTime,
+  local_path: outPath,
+  local_exists_before: localExists,
+  bytes_written: finalContent.length,
+}, null, 2));
+
+// =================================================================
+// helpers
+// =================================================================
+
+function parseArgs(argv) {
+  const out = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) {
+      out._.push(a);
+      continue;
+    }
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith("--")) {
+      out[key] = next;
+      i++;
+    } else {
+      out[key] = true;
+    }
+  }
+  return out;
+}
+
+// --out 未指定時の出力先: カレントディレクトリの ./<Docタイトル>.md。
+// ファイル名に使えない文字だけ _ に置換する。
+function autoResolveOutPath(docTitle) {
+  const safe = (docTitle || "imported-doc")
+    .replace(/[\/\\:*?"<>|\n\r\t]/g, "_")
+    .trim();
+  return resolve(process.cwd(), `${safe}.md`);
+}
+
+function getLastCommittedTime(filePath) {
+  // git log -1 --format=%aI -- <path> でファイルの最終 commit 時刻を取得
+  // 1度も commit されていない場合は null を返す（ローカル新規ファイル）
+  try {
+    const out = execSync(`git log -1 --format=%aI -- "${filePath}"`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+function computeIsStale(docTimeIso, localTimeIso, localExists) {
+  // ローカルファイルが存在しない: 取り込みが必要なので stale 扱い
+  if (!localExists) return true;
+  // git に commit されていない: 判定不能なので stale 扱い（安全側）
+  if (!localTimeIso) return true;
+  return new Date(docTimeIso).getTime() > new Date(localTimeIso).getTime();
+}
+
+function buildOutput({ client, taskTitle, docTitle, docUrl, docModifiedTime, bodyMd, mode }) {
+  const modeNote = mode === "PREVIEW_SUGGESTIONS_ACCEPTED"
+    ? "PREVIEW_SUGGESTIONS_ACCEPTED （提案モードでの編集は反映済み）"
+    : "DEFAULT_FOR_CURRENT_ACCESS （viewer 権限のためフォールバック取得・提案中の編集は反映されない可能性）";
+  return `> **source:** ${docUrl}
+> **client:** ${client}
+> **task:** ${taskTitle}
+> **doc title:** ${docTitle}
+> **doc modified at:** ${docModifiedTime}
+> **fetched at:** ${new Date().toISOString()}
+> **suggestionsViewMode:** ${modeNote}
+
+---
+
+${bodyMd}
+`;
+}

--- a/bin/lib/doc-to-markdown.mjs
+++ b/bin/lib/doc-to-markdown.mjs
@@ -1,0 +1,249 @@
+// Google Docs API のレスポンスを Markdown に変換する共通モジュール。
+//
+// 対象ユーザー: apps/web/scripts/ 配下の .mjs スクリプト
+//   - extract-product-design.mjs（商品設計 Doc 取り込み）
+//   - sync-doc-to-md.mjs（任意タスクの Doc → .md 同期）
+//   - 将来: 他の Doc を取り込むスクリプトでも再利用可
+//
+// 提供する関数:
+//   - extractDocId(url)                      — URL から Doc ID を取り出す
+//   - docToMarkdown(doc)                     — Docs API レスポンス → Markdown
+//   - getDocWithSuggestionFallback(docs, id) — 提案モード反映済みで取得（権限が無ければ通常モードへフォールバック）
+//
+// 設計メモ:
+// - getDocWithSuggestionFallback は googleapis の docs クライアント（呼び出し側で初期化）を受け取る
+//   → このモジュール自体は Google API 認証を持たない（テスタブルで結合度低）
+// - 提案モードビュー (PREVIEW_SUGGESTIONS_ACCEPTED) は commenter+ 権限が必要。
+//   viewer 権限しかない Doc では通常モードにフォールバックする。
+
+const HEADING_PREFIX = {
+  HEADING_1: "# ",
+  HEADING_2: "## ",
+  HEADING_3: "### ",
+  HEADING_4: "#### ",
+  HEADING_5: "##### ",
+  HEADING_6: "###### ",
+  TITLE: "# ",
+  SUBTITLE: "## ",
+};
+
+// =================================================================
+// 公開 API
+// =================================================================
+
+export function extractDocId(url) {
+  const m = url.match(/\/d\/([a-zA-Z0-9_-]+)/);
+  return m ? m[1] : null;
+}
+
+export async function getDocWithSuggestionFallback(docs, documentId) {
+  try {
+    const r = await docs.documents.get({
+      documentId,
+      includeTabsContent: true,
+      suggestionsViewMode: "PREVIEW_SUGGESTIONS_ACCEPTED",
+    });
+    return { data: r.data, mode: "PREVIEW_SUGGESTIONS_ACCEPTED" };
+  } catch (e) {
+    const msg = e?.errors?.[0]?.message || e?.message || "";
+    if (e?.code === 403 || /permission|suggestion/i.test(msg)) {
+      const r = await docs.documents.get({ documentId, includeTabsContent: true });
+      return { data: r.data, mode: "DEFAULT_FOR_CURRENT_ACCESS", fallback: true };
+    }
+    throw e;
+  }
+}
+
+export function docToMarkdown(doc) {
+  // inline image は ![imageN] のプレースホルダーで位置だけ残す。
+  // 画像バイナリ自体は取り込まず、運用側（LINE 配信ツール等）で都度貼る前提。
+  // カウンタは doc 全体で連番にしたいので docToMarkdown スコープでリセット。
+  imageCounter = 0;
+
+  const tabs = doc.tabs;
+  const segments = [];
+  if (tabs?.length) {
+    for (const tab of flattenTabs(tabs)) {
+      const props = tab.tabProperties;
+      const tabContent = tab.documentTab?.body?.content ?? [];
+      if (tabs.length > 1 && props?.title) {
+        segments.push(`<!-- tab: ${props.title} -->\n`);
+      }
+      segments.push(contentToMarkdown(tabContent, doc.lists));
+    }
+  } else {
+    segments.push(contentToMarkdown(doc.body?.content ?? [], doc.lists));
+  }
+  return segments.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+let imageCounter = 0;
+
+// =================================================================
+// 内部ヘルパー
+// =================================================================
+
+function flattenTabs(tabs) {
+  const out = [];
+  for (const tab of tabs) {
+    out.push(tab);
+    if (tab.childTabs?.length) out.push(...flattenTabs(tab.childTabs));
+  }
+  return out;
+}
+
+function contentToMarkdown(content, lists) {
+  const out = [];
+  for (const el of content) {
+    if (el.paragraph) {
+      out.push(paragraphToMarkdown(el.paragraph, lists));
+    } else if (el.table) {
+      out.push(tableToMarkdown(el.table, lists));
+    }
+  }
+  return out.filter((s) => s !== null).join("\n");
+}
+
+function paragraphToMarkdown(para, lists) {
+  const style = para.paragraphStyle?.namedStyleType;
+  const prefix = HEADING_PREFIX[style] ?? "";
+
+  let text = "";
+  for (const run of para.elements ?? []) {
+    if (run.textRun) {
+      text += textRunToMarkdown(run.textRun);
+    } else if (run.richLink?.richLinkProperties) {
+      const props = run.richLink.richLinkProperties;
+      text += `[${props.title || props.uri}](${props.uri})`;
+    } else if (run.inlineObjectElement) {
+      imageCounter++;
+      text += `![image${imageCounter}]`;
+    }
+  }
+  text = text.replace(/\n$/, "");
+  if (!text.trim()) return "";
+
+  const bullet = para.bullet;
+  if (bullet) {
+    const nesting = bullet.nestingLevel || 0;
+    const indent = "  ".repeat(nesting);
+    const glyph = guessListGlyph(bullet, lists);
+    return `${indent}${glyph} ${text}`;
+  }
+
+  if (prefix) return `\n${prefix}${text}\n`;
+  return text;
+}
+
+function textRunToMarkdown(run) {
+  let t = normalizeDocText(run.content || "");
+  if (!t) return "";
+  const style = run.textStyle || {};
+  const link = style.link?.url;
+  const trimmedNewline = t.endsWith("\n");
+  let body = trimmedNewline ? t.slice(0, -1) : t;
+
+  if (body.trim()) {
+    if (style.bold) body = `**${body}**`;
+    if (style.italic) body = `*${body}*`;
+    if (link) body = `[${body}](${link})`;
+  }
+  return trimmedNewline ? body + "\n" : body;
+}
+
+function guessListGlyph(bullet, lists) {
+  const listId = bullet.listId;
+  const list = listId && lists?.[listId];
+  const level = list?.listProperties?.nestingLevels?.[bullet.nestingLevel || 0];
+  const glyphFmt = level?.glyphFormat;
+  if (glyphFmt && /%\d+/.test(glyphFmt)) return "1.";
+  return "-";
+}
+
+function tableToMarkdown(table, lists) {
+  // Google Docs の Code Block は「1×1 / 背景がほぼ均一なグレー」のテーブルで表現される。
+  // これを通常の markdown table に変換すると改行がスペースに潰れてしまうため、
+  // 検出した場合は ``` フェンスで包んで改行を保持する。
+  if (isCodeBlockTable(table)) {
+    return tableToCodeBlock(table, lists);
+  }
+
+  const rows = [];
+  for (const row of table.tableRows ?? []) {
+    const cells = [];
+    for (const cell of row.tableCells ?? []) {
+      const cellText = contentToMarkdown(cell.content ?? [], lists)
+        .replace(/\n+/g, " ")
+        .replace(/\|/g, "\\|")
+        .trim();
+      cells.push(cellText || " ");
+    }
+    rows.push(cells);
+  }
+  if (!rows.length) return "";
+  const colCount = Math.max(...rows.map((r) => r.length));
+  const md = [];
+  md.push("| " + rows[0].concat(Array(colCount - rows[0].length).fill("")).join(" | ") + " |");
+  md.push("| " + Array(colCount).fill("---").join(" | ") + " |");
+  for (const row of rows.slice(1)) {
+    md.push("| " + row.concat(Array(colCount - row.length).fill("")).join(" | ") + " |");
+  }
+  return "\n" + md.join("\n") + "\n";
+}
+
+function isCodeBlockTable(table) {
+  const rows = table.tableRows ?? [];
+  if (rows.length !== 1) return false;
+  const cells = rows[0].tableCells ?? [];
+  if (cells.length !== 1) return false;
+  const bg = cells[0].tableCellStyle?.backgroundColor?.color?.rgbColor;
+  return isGreyBackground(bg);
+}
+
+function isGreyBackground(rgb) {
+  if (!rgb) return false;
+  const r = rgb.red ?? 0;
+  const g = rgb.green ?? 0;
+  const b = rgb.blue ?? 0;
+  // 各チャンネルが 0.85〜0.97 かつほぼ均一（無彩色）= 薄いグレー = Code Block 背景
+  const inRange = (v) => v >= 0.85 && v <= 0.97;
+  if (!inRange(r) || !inRange(g) || !inRange(b)) return false;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  return max - min < 0.03;
+}
+
+function tableToCodeBlock(table, lists) {
+  const cell = table.tableRows[0].tableCells[0];
+  // contentToMarkdown は paragraph を "\n" で join するので、改行構造が保たれる。
+  // ただし bold/italic/link 装飾が markdown で混ざると ``` の中で生で出てしまうため、
+  // 装飾を捨てた素のテキスト抽出に切り替える。
+  const text = extractPlainText(cell.content ?? []).replace(/\n+$/, "");
+  return "\n```\n" + text + "\n```\n";
+}
+
+function extractPlainText(content) {
+  const parts = [];
+  for (const el of content) {
+    if (!el.paragraph) continue;
+    let line = "";
+    for (const run of el.paragraph.elements ?? []) {
+      if (run.textRun) {
+        line += normalizeDocText(run.textRun.content || "");
+      } else if (run.richLink?.richLinkProperties) {
+        line += run.richLink.richLinkProperties.title || run.richLink.richLinkProperties.uri || "";
+      } else if (run.inlineObjectElement) {
+        imageCounter++;
+        line += `![image${imageCounter}]`;
+      }
+    }
+    line = line.replace(/\n$/, "");
+    parts.push(line);
+  }
+  return parts.join("\n");
+}
+
+function normalizeDocText(text) {
+  // Google Docs API returns soft line breaks as vertical tabs in some documents.
+  return text.replace(/\v/g, "\n");
+}

--- a/bin/md2gdoc
+++ b/bin/md2gdoc
@@ -1,0 +1,457 @@
+#!/usr/bin/env -S deno run -A --ext=js
+// @ts-nocheck
+// Markdown を Google Doc（LINEメッセージ形式）に流し込む standalone CLI。
+// gdoc2md（Doc→md）の逆変換にあたる。
+//
+// Deno で動くため repo 非依存・ローカル node_modules 不要。
+//
+// 対応する Markdown 構造:
+//   - `<!-- tab: タイトル -->`         複数タブ。出現順に Doc のタブへ割り当てる
+//   - `# ` / `## ` / `### `            HEADING_1 / 2 / 3（ドキュメント先頭の見出しのみ TITLE）
+//   - ` ``` ` で囲んだコードブロック    1x1 のグレー（#efefef）テーブル＝LINE 1通分
+//   - それ以外の行                     NORMAL_TEXT 段落（空行も段落として保持）
+//   - インライン **太字** と [文字](URL) リンクは書式付きで反映
+//   - ` ```mermaid ` 等の言語付きフェンス  Doc では描画不可のため出力しない
+//   - 画像参照 ![imageN] は文字としてそのまま残す（画像本体は手で貼り直す前提）
+//   - 先頭の `>` 引用ヘッダや `---`、最初の `<!-- tab -->` / `＜…＞` 見出しより前は無視
+//
+// タブの割り当て:
+//   - Markdown のタブ数 ≤ Doc のタブ数 が必須（タブ作成は Docs API 非対応のため）。
+//   - Markdown のタブと Doc のタブを「出現順」で対応づける（タブ名では照合しない）。
+//   - 余った Doc タブは触らない。
+//   - `<!-- tab -->` が無い Markdown は最初のタブだけを対象にする。
+//
+// 冪等性: --doc-id を渡せば既存 Doc を再利用する。対象タブは毎回クリア→再構築されるので
+// 同じ .md と同じ --doc-id を指定すれば何度実行しても同じ結果になる。
+// --doc-id を省略した場合のみテンプレからの新規コピーを行う。
+//
+// Usage:
+//   md2gdoc <md-path> [--doc-id <id>] [--name <doc-name>] [--folder <folder-id>] [--template <doc-id>] [--dry-run]
+//
+// --dry-run: Google API を叩かず、パース結果（タブ・ブロック・メッセージ数）だけ表示する。
+//
+// 認証: ~/dotfiles/.env.local の GOOGLE_SERVICE_ACCOUNT_KEY 等を使う。
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, isAbsolute } from "node:path";
+import { homedir } from "node:os";
+
+// --- env (~/dotfiles/.env.local) ---
+const ENV_PATH = resolve(homedir(), "dotfiles/.env.local");
+if (!existsSync(ENV_PATH)) {
+  console.error(`.env.local が見つかりません: ${ENV_PATH}`);
+  process.exit(1);
+}
+for (const line of readFileSync(ENV_PATH, "utf8").split("\n")) {
+  const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+  if (!m) continue;
+  let v = m[2];
+  if (v.startsWith('"') && v.endsWith('"')) v = v.slice(1, -1);
+  if (!process.env[m[1]]) process.env[m[1]] = v;
+}
+
+// 外部パッケージ解決: Deno なら npm: 指定、node なら bare specifier。
+const NPM = typeof Deno !== "undefined" ? "npm:" : "";
+const { google } = await import(`${NPM}googleapis`);
+
+// 汎用ドキュメント雛形（見出し h1〜h6 の色定義のみを継承する用途・1タブ）
+const DEFAULT_TEMPLATE_ID = "168k8wuUAYN3HQhWxlFi7icw_v9yH1ilL8dPr5oAKENA";
+
+// --- args ---
+const args = process.argv.slice(2);
+const mdPath = args.find((a) => !a.startsWith("--"));
+if (!mdPath) {
+  console.error("Usage: md2gdoc <md-path> [--doc-id <id>] [--name <doc-name>] [--folder <folder-id>] [--template <doc-id>] [--dry-run]");
+  process.exit(1);
+}
+const flag = (name, fallback = null) => {
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : fallback;
+};
+const docName = flag("--name", "LINEメッセージ_テンプレ");
+const folderId = flag("--folder", null);
+const templateId = flag("--template", DEFAULT_TEMPLATE_ID);
+const existingDocId = flag("--doc-id", null);
+const dryRun = args.includes("--dry-run");
+
+const md = readFileSync(isAbsolute(mdPath) ? mdPath : resolve(process.cwd(), mdPath), "utf8");
+
+// --- auth ---
+const keyJson = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+if (!keyJson) {
+  console.error("GOOGLE_SERVICE_ACCOUNT_KEY が .env.local にありません。");
+  process.exit(1);
+}
+const sanitized = keyJson.replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
+const credentials = JSON.parse(sanitized);
+const impersonateEmail = process.env.GOOGLE_IMPERSONATE_EMAIL;
+const auth = new google.auth.GoogleAuth({
+  credentials,
+  scopes: [
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/drive",
+  ],
+  ...(impersonateEmail ? { clientOptions: { subject: impersonateEmail } } : {}),
+});
+const docs = google.docs({ version: "v1", auth });
+const drive = google.drive({ version: "v3", auth });
+
+// =================================================================
+// Markdown パーサ
+// =================================================================
+// 出力: [{ title, blocks: Block[] }]   ← タブ単位
+//   Block = { type:"heading", level:1|2|3, text }
+//         | { type:"para", text }            ← 空行は text:"" の para
+//         | { type:"code", text }            ← コードブロック1通分（プレーンテキスト）
+
+function parseDoc(text) {
+  const lines = text.split("\n");
+  const tabs = [];
+  let current = null;
+  let started = false;
+  let i = 0;
+
+  const ensureTab = (title) => {
+    current = { title, blocks: [] };
+    tabs.push(current);
+  };
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    const tabMatch = line.match(/^<!--\s*tab:\s*(.*?)\s*-->\s*$/);
+    if (tabMatch) {
+      started = true;
+      ensureTab(tabMatch[1]);
+      i++; continue;
+    }
+
+    const headingMatch = line.match(/^(#{1,3})\s+(.*\S)\s*$/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const htext = headingMatch[2].trim();
+      if (!started) {
+        // イントロ中: `＜…＞` で始まる H1 を境にコンテンツ開始（タブ markers が無い形式）
+        if (level === 1 && htext.startsWith("＜")) {
+          started = true;
+        } else {
+          i++; continue; // イントロ見出しは無視
+        }
+      }
+      if (!current) ensureTab(null);
+      current.blocks.push({ type: "heading", level, text: htext });
+      i++; continue;
+    }
+
+    if (!started) { i++; continue; } // イントロ（`>` ヘッダ・`---`・空行など）
+
+    const fenceMatch = line.match(/^```(\S*)\s*$/);
+    if (fenceMatch) {
+      const lang = fenceMatch[1];
+      const buf = [];
+      i++;
+      while (i < lines.length && !/^```\s*$/.test(lines[i])) {
+        buf.push(lines[i]);
+        i++;
+      }
+      i++; // closing ```
+      // 言語なしフェンス = LINE 1通分 → テーブル化。
+      // 言語付きフェンス（```mermaid 等）= Doc では描画できないため出力しない（.md 専用）。
+      if (lang === "") {
+        current.blocks.push({ type: "code", text: buf.join("\n").replace(/\s+$/, "") });
+      }
+      continue;
+    }
+
+    if (line.trim() === "---") { i++; continue; } // 水平線は無視
+
+    current.blocks.push({ type: "para", text: line });
+    i++;
+  }
+  return tabs;
+}
+
+// 構造由来の空行を間引く: 空 para は「前後ともに非空 para」のときだけ残す
+// （見出し・テーブルの直前直後の空行は落とす。本文内の段落区切りは保つ）
+function cleanBlocks(blocks) {
+  const isBlank = (b) => b && b.type === "para" && b.text.trim() === "";
+  const out = [];
+  for (let j = 0; j < blocks.length; j++) {
+    const b = blocks[j];
+    if (isBlank(b)) {
+      const prev = out[out.length - 1];
+      const next = blocks[j + 1];
+      if (isBlank(prev) || !prev || prev.type !== "para") continue;
+      if (isBlank(next) || !next || next.type !== "para") continue;
+    }
+    out.push(b);
+  }
+  return out;
+}
+
+// インライン書式: **太字** と [文字](URL) を剥がしてプレーンテキスト＋スタイル範囲を返す
+function parseInline(raw) {
+  let text = "";
+  const ranges = [];
+  let i = 0;
+  while (i < raw.length) {
+    if (raw.startsWith("**", i)) {
+      const close = raw.indexOf("**", i + 2);
+      if (close !== -1) {
+        const inner = raw.slice(i + 2, close);
+        const s = text.length;
+        text += inner;
+        if (text.length > s) {
+          ranges.push({ start: s, end: text.length, style: { bold: true }, fields: "bold" });
+        }
+        i = close + 2;
+        continue;
+      }
+    }
+    const linkM = /^\[([^\]]*)\]\(([^)]+)\)/.exec(raw.slice(i));
+    if (linkM) {
+      const s = text.length;
+      text += linkM[1];
+      if (text.length > s) {
+        ranges.push({ start: s, end: text.length, style: { link: { url: linkM[2] } }, fields: "link" });
+      }
+      i += linkM[0].length;
+      continue;
+    }
+    text += raw[i];
+    i++;
+  }
+  return { text, ranges };
+}
+
+// =================================================================
+// Doc ヘルパ
+// =================================================================
+async function getAllTabs(documentId) {
+  const doc = (await docs.documents.get({ documentId, includeTabsContent: true })).data;
+  return doc.tabs ?? [];
+}
+
+async function getTab(documentId, tabId) {
+  const tabs = await getAllTabs(documentId);
+  const tab = tabs.find((t) => t.tabProperties?.tabId === tabId);
+  if (!tab) throw new Error(`tabId not found: ${tabId}`);
+  return tab;
+}
+
+async function getTabEndIndex(documentId, tabId) {
+  const tab = await getTab(documentId, tabId);
+  const content = tab.documentTab?.body?.content ?? [];
+  return content[content.length - 1].endIndex;
+}
+
+async function getLastTableLocation(documentId, tabId) {
+  const tab = await getTab(documentId, tabId);
+  const content = tab.documentTab?.body?.content ?? [];
+  for (let i = content.length - 1; i >= 0; i--) {
+    const el = content[i];
+    if (el.table) {
+      const cell = el.table.tableRows[0].tableCells[0];
+      const para = cell.content[0];
+      return { tableStart: el.startIndex, cellStart: para.startIndex };
+    }
+  }
+  return null;
+}
+
+async function batchUpdate(documentId, requests) {
+  if (!requests.length) return;
+  await docs.documents.batchUpdate({ documentId, requestBody: { requests } });
+}
+
+async function clearTab(documentId, tabId) {
+  const lastEnd = await getTabEndIndex(documentId, tabId);
+  if (lastEnd > 2) {
+    await batchUpdate(documentId, [
+      { deleteContentRange: { range: { startIndex: 1, endIndex: lastEnd - 1, segmentId: "", tabId } } },
+    ]);
+  }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Google Docs「明るいグレー3」: #efefef
+const LIGHT_GRAY_3 = { color: { rgbColor: { red: 239 / 255, green: 239 / 255, blue: 239 / 255 } } };
+const HIDDEN_BORDER = {
+  color: LIGHT_GRAY_3,
+  width: { magnitude: 0, unit: "PT" },
+  dashStyle: "SOLID",
+};
+
+const HEADING_STYLE = { 1: "HEADING_1", 2: "HEADING_2", 3: "HEADING_3" };
+
+// コードブロック1通分を 1x1 グレーテーブルとして末尾に追加する
+async function appendTable(documentId, tabId, cellText) {
+  const end = await getTabEndIndex(documentId, tabId);
+  const cursor = end - 1;
+  await batchUpdate(documentId, [
+    { insertTable: { rows: 1, columns: 1, location: { index: cursor, tabId } } },
+    { insertText: { text: "\n", endOfSegmentLocation: { tabId } } },
+  ]);
+  await sleep(1200);
+
+  const loc = await getLastTableLocation(documentId, tabId);
+  if (!loc) throw new Error("table not found after insert");
+  const text = cellText.length ? cellText : " ";
+  await batchUpdate(documentId, [
+    { insertText: { text, location: { index: loc.cellStart, tabId } } },
+    {
+      updateParagraphStyle: {
+        range: { startIndex: loc.cellStart, endIndex: loc.cellStart + text.length, tabId },
+        paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
+        fields: "namedStyleType",
+      },
+    },
+    {
+      updateTableCellStyle: {
+        tableStartLocation: { index: loc.tableStart, tabId },
+        tableCellStyle: {
+          backgroundColor: LIGHT_GRAY_3,
+          borderTop: HIDDEN_BORDER,
+          borderRight: HIDDEN_BORDER,
+          borderBottom: HIDDEN_BORDER,
+          borderLeft: HIDDEN_BORDER,
+        },
+        fields: "backgroundColor,borderTop,borderRight,borderBottom,borderLeft",
+      },
+    },
+  ]);
+  await sleep(1200);
+}
+
+// 1タブ分のブロック列を Doc に流し込む。
+// 連続する非テーブルブロック（見出し・段落）は1回の batchUpdate にまとめる。
+async function buildTab(documentId, tabId, blocks, state) {
+  let pending = [];
+  let cursor = null;
+
+  const flush = async () => {
+    if (pending.length) await batchUpdate(documentId, pending);
+    pending = [];
+    cursor = null;
+  };
+
+  for (const block of blocks) {
+    if (block.type === "code") {
+      await flush();
+      await appendTable(documentId, tabId, block.text);
+      continue;
+    }
+
+    if (cursor === null) {
+      cursor = (await getTabEndIndex(documentId, tabId)) - 1;
+    }
+
+    let namedStyle;
+    if (block.type === "heading") {
+      namedStyle = state.firstHeadingDone ? HEADING_STYLE[block.level] : "TITLE";
+      state.firstHeadingDone = true;
+    } else {
+      namedStyle = "NORMAL_TEXT";
+    }
+
+    const { text, ranges } = parseInline(block.text);
+    const start = cursor;
+    pending.push({ insertText: { text: text + "\n", location: { index: cursor, tabId } } });
+    cursor += text.length + 1;
+    pending.push({
+      updateParagraphStyle: {
+        range: { startIndex: start, endIndex: start + 1, tabId },
+        paragraphStyle: { namedStyleType: namedStyle },
+        fields: "namedStyleType",
+      },
+    });
+    for (const r of ranges) {
+      if (r.end <= r.start) continue;
+      pending.push({
+        updateTextStyle: {
+          range: { startIndex: start + r.start, endIndex: start + r.end, tabId },
+          textStyle: r.style,
+          fields: r.fields,
+        },
+      });
+    }
+  }
+  await flush();
+}
+
+// =================================================================
+// main
+// =================================================================
+const mdTabs = parseDoc(md).map((t) => ({ title: t.title, blocks: cleanBlocks(t.blocks) }));
+if (!mdTabs.length) {
+  console.error("Markdown からコンテンツを検出できませんでした（`<!-- tab -->` も `＜…＞` 見出しも無い）。");
+  process.exit(1);
+}
+console.error(`Markdown: ${mdTabs.length} タブ検出`);
+for (const t of mdTabs) {
+  const msgs = t.blocks.filter((b) => b.type === "code").length;
+  console.error(`  - ${t.title ?? "(タブ指定なし)"}: ${t.blocks.length} ブロック / ${msgs} メッセージ`);
+}
+
+if (dryRun) {
+  for (const t of mdTabs) {
+    console.error(`\n── ${t.title ?? "(タブ指定なし)"} ──`);
+    for (const b of t.blocks) {
+      if (b.type === "heading") console.error(`  H${b.level}  ${b.text}`);
+      else if (b.type === "code") console.error(`  [msg] ${b.text.split("\n")[0].slice(0, 40)}… (${b.text.split("\n").length}行)`);
+      else console.error(`  p   ${b.text === "" ? "(空行)" : b.text.slice(0, 50)}`);
+    }
+  }
+  console.error("\n(--dry-run のため Google Doc は変更していません)");
+  process.exit(0);
+}
+
+let newDocId;
+if (existingDocId) {
+  console.error(`\nReusing existing doc ${existingDocId} (idempotent rebuild)...`);
+  newDocId = existingDocId;
+} else {
+  console.error(`\nCopying template ${templateId}...`);
+  const copyResp = await drive.files.copy({
+    fileId: templateId,
+    requestBody: { name: docName, ...(folderId ? { parents: [folderId] } : {}) },
+    supportsAllDrives: true,
+  });
+  newDocId = copyResp.data.id;
+  console.error(`New doc: ${newDocId}`);
+}
+
+const docTabs = await getAllTabs(newDocId);
+if (!docTabs.length) throw new Error("Doc にタブがありません");
+if (mdTabs.length > docTabs.length) {
+  console.error(
+    `\n✗ Markdown は ${mdTabs.length} タブ必要ですが、対象 Doc は ${docTabs.length} タブしかありません。`,
+  );
+  console.error("  Docs API はタブを作成できません。対象 Doc / テンプレを必要なタブ数に手動で増やしてから再実行してください。");
+  process.exit(1);
+}
+
+console.error("\nタブ割り当て（Markdown 出現順 → Doc 出現順）:");
+const assignments = mdTabs.map((t, i) => {
+  const docTab = docTabs[i];
+  console.error(`  [${i + 1}] ${t.title ?? "(指定なし)"}  →  Docタブ「${docTab.tabProperties?.title ?? "?"}」`);
+  return { mdTab: t, tabId: docTab.tabProperties?.tabId };
+});
+if (docTabs.length > mdTabs.length) {
+  console.error(`  ※ 残り ${docTabs.length - mdTabs.length} タブは変更しません。`);
+}
+
+const state = { firstHeadingDone: false };
+for (let i = 0; i < assignments.length; i++) {
+  const { mdTab, tabId } = assignments[i];
+  console.error(`\n[タブ ${i + 1}/${assignments.length}] ${mdTab.title ?? "(指定なし)"} を再構築...`);
+  await clearTab(newDocId, tabId);
+  const msgTotal = mdTab.blocks.filter((b) => b.type === "code").length;
+  await buildTab(newDocId, tabId, mdTab.blocks, state);
+  console.error(`  ✓ ${msgTotal} メッセージを反映`);
+}
+
+console.error("\n✓ Done.");
+console.error("※ 画像 ![imageN] は文字として残っています。Doc 上で実画像に貼り替えてください。");
+console.log(`https://docs.google.com/document/d/${newDocId}/edit`);

--- a/bin/md2gdoc
+++ b/bin/md2gdoc
@@ -242,7 +242,7 @@ async function getTab(documentId, tabId) {
 async function getTabEndIndex(documentId, tabId) {
   const tab = await getTab(documentId, tabId);
   const content = tab.documentTab?.body?.content ?? [];
-  return content[content.length - 1].endIndex;
+  return content[content.length - 1]?.endIndex ?? 2;
 }
 
 async function getLastTableLocation(documentId, tabId) {
@@ -251,8 +251,9 @@ async function getLastTableLocation(documentId, tabId) {
   for (let i = content.length - 1; i >= 0; i--) {
     const el = content[i];
     if (el.table) {
-      const cell = el.table.tableRows[0].tableCells[0];
-      const para = cell.content[0];
+      const cell = el.table?.tableRows?.[0]?.tableCells?.[0];
+      const para = cell?.content?.[0];
+      if (typeof el.startIndex !== "number" || typeof para?.startIndex !== "number") continue;
       return { tableStart: el.startIndex, cellStart: para.startIndex };
     }
   }


### PR DESCRIPTION
## Summary
- Add `gdoc2md`, a standalone CLI that fetches a Google Doc from a direct URL or Supabase task `external_url`, converts it to Markdown, and can report stale local Markdown using Drive `modifiedTime` vs git commit time.
- Add `bin/lib/doc-to-markdown.mjs` for shared Docs API response to Markdown conversion, including tabs, headings, lists, rich links, inline image placeholders, normal tables, and gray 1x1 code-block tables.
- Add `md2gdoc`, a standalone CLI that imports Markdown back into a Google Doc by rebuilding target tabs in order, applying heading/paragraph styles, bold/link ranges, and LINE-message code fences as gray 1x1 tables.

## Verification
- `deno check --quiet bin/gdoc2md`
- `deno check --quiet bin/md2gdoc`
- `deno check --quiet bin/lib/doc-to-markdown.mjs`
- `node --check bin/gdoc2md`
- `node --check bin/md2gdoc`
- `./bin/md2gdoc <sample markdown> --dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Google Docs から Markdown への変換 CLI を追加。URL または Supabase 経由で Doc を取得し、見出し・リスト・テーブル・画像などを Markdown 化。鮮度判定と差分検出にも対応。
  * Markdown から Google Docs への変換 CLI を追加。タブ区切り対応で、見出し・段落・コードブロック・スタイルをドキュメント内に反映。ドライラン機能も搭載。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shuntagami/dotfiles/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->